### PR TITLE
Disambiguation in INTRO and swirl2rnw.R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,6 +2,7 @@ Description: Test swirl course and lesson files, yaml etc, at the time of submit
 URL: http://swirlstats.com
 Depends:
     R (>= 3.0.2)
-Imports:
-    swirl
+Imports: swirl
+  glue
+  yaml
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Description: Test swirl course and lesson files, yaml etc, at the time of submit
 URL: http://swirlstats.com
 Depends:
     R (>= 3.0.2)
-Imports: swirl
-  glue
+Imports: swirl,
+  glue,
   yaml
 License: GPL-3

--- a/INTRO1/customTests.R
+++ b/INTRO1/customTests.R
@@ -10,3 +10,32 @@
 # variables when appropriate. The answer test, creates_new_var()
 # can be used for for the purpose, but it also re-evaluates the
 # expression which the user entered, so care must be taken.
+
+# Get the swirl state
+getState <- function(){
+  # Whenever swirl is running, its callback is at the top of its call stack.
+  # Swirl's state, named e, is stored in the environment of the callback.
+  environment(sys.function(1))$e
+}
+
+# Retrieve the log from swirl's state
+getLog <- function(){
+  getState()$log
+}
+
+submit_log <- function(){
+  p <- function(x, p, f, l = length(x)){if(l < p){x <- c(x, rep(f, p - l))};x}
+
+  log_ <- getLog()
+  nrow_ <- max(unlist(lapply(log_, length)))
+  log_tbl <- data.frame(user = rep(log_$user, nrow_),
+                        course_name = rep(log_$course_name, nrow_),
+                        lesson_name = rep(log_$lesson_name, nrow_),
+                        question_number = p(log_$question_number, nrow_, NA),
+                        correct = p(log_$correct, nrow_, NA),
+                        attempt = p(log_$attempt, nrow_, NA),
+                        skipped = p(log_$skipped, nrow_, NA),
+                        datetime = p(log_$datetime, nrow_, NA),
+                        stringsAsFactors = FALSE)
+  print(log_tbl)
+}

--- a/INTRO1/initLesson.R
+++ b/INTRO1/initLesson.R
@@ -6,6 +6,8 @@
 # UNpop <- read.csv("UNpop.csv", head = T)
 # world.pop <- UNpop$world.pop
 
+swirl_options(swirl_logging = TRUE)
+
 year <- seq(from = 1950, to = 2010, by = 10)
 world.pop <- c(2525779, 3026003, 3691173, 4449049, 5320817, 6127700, 6916183)
 UNpop <- as.data.frame(cbind(world.pop, year))

--- a/INTRO1/lesson.yaml
+++ b/INTRO1/lesson.yaml
@@ -1,7 +1,7 @@
 - Class: meta
   Course: qss-swirl
   Lesson: INTRO1
-  Author: Elisha Cohen, Kosuke Imai
+  Author: Elisha Cohen, Kosuke Imai, Will Lowe
   Type: Standard
   Organization: Princeton University
   Version: 2.3.0
@@ -13,7 +13,7 @@
   Output: 'If at any time you need help with R, you can type help.start() at the prompt which will open an index of R materials. Many R resources are also available on the web and are easily found through a web search.'
 
 - Class: text
-  Output: 'We will highlight R objects by putting double quotes around them. However, in actual R code, there is usually no need to put quotation marks around objects.'
+  Output: 'We will put double quotes around the names of R objects. However, in actual R code, there are only a few cases where you will need to put them in quotation marks.'
 
 - Class: text
   Output: 'Let''s start by practicing arithmetic operations by using R as a basic calculator.'
@@ -40,28 +40,28 @@
   Hint: See 'Arithmetic Operations'.
 
 - Class: text
-  Output: 'Next, we will practice creating objects and assigning values to them.'
+  Output: 'Next, we will practice creating objects and giving them names.'
 
 # Question 4
 - Class: cmd_question
-  Output: 'Try assigning the value 8 - 2 to the object "result".'
+  Output: 'Try assigning 8 - 2 the name "result".'
   CorrectAnswer: 'result <- 8 - 2'
   AnswerTests: omnitest(correctExpr='result <- 8 - 2')
   Hint: See 'Objects'.
 
 # Question 5
 - Class: cmd_question
-  Output: 'Call the object "result" that we created above.'
+  Output: 'Type the name of the object we created above.'
   CorrectAnswer: 'result'
   AnswerTests: omnitest(correctExpr='result')
   Hint: See 'Objects'.
 
 - Class: text
-  Output: 'We can also assign a string of characters to an object.'
+  Output: 'We can also give a name to a string of characters'
 
 # Question 6
 - Class: cmd_question
-  Output: 'Assign the phrase ''social science'' to the object "course".'
+  Output: 'Give the phrase ''social science'' the name "course".'
   CorrectAnswer: 'course <- "social science"'
   AnswerTests: omnitest(correctExpr='course <- "social science"')
   Hint: See 'Objects'.
@@ -70,35 +70,66 @@
   Output: 'Notice that spaces are allowed in character strings.'
 
 - Class: text
-  Output: 'We can also reassign new values to objects.'
+  Output: 'We can also change what a name refers to by assigning a new object to the name.'
 
 # Question 7
 - Class: cmd_question
-  Output: 'Reassign the phrase ''learning R'' to the object "course", which we defined above.'
+  Output: 'Now make "course" refer to ''learning R''.'
   CorrectAnswer: 'course <- "learning R"'
   AnswerTests: omnitest(correctExpr='course <- "learning R"')
   Hint: See 'Objects'.'
 
 - Class: text
-  Output: 'Next, we are going to start working with real data estimates of world population (in thousands). A vector of data called "world.pop" has been loaded with this lesson. The first element is for the year 1950 up to the last element for 2010.'
+  Output: 'When we assign an existing object to a new name we make a copy.'
 
 # Question 8
 - Class: cmd_question
-  Output: 'Call the object "world.pop" to see what it looks like.'
+  Output: 'Assign "result2" to "result".'
+  CorrectAnswer: 'result2 <- result'
+  AnswerTests: omnitest(correctExpr='result2 <- result')
+  Hint: See 'Objects'.'
+
+# Question 9
+- Class: cmd_question
+  Output: 'Now change "result" to be the value of 10 minus 2'
+  CorrectAnswer: 'result <- 10 - 2'
+  AnswerTests: omnitest(correctExpr='result <- 10 - 2')
+  Hint: See 'Objects'.'
+
+# Question 10
+- Class: cmd_question
+  Output: 'What is the value of "result2"?'
+  CorrectAnswer: 'result2'
+  AnswerTests: omnitest(correctExpr='result2')
+  Hint: See 'Objects'.'
+
+# Question 11
+- Class: mult_question
+  Output: 'What do you think R will return when we type "c(result, result2)"?'
+  AnswerChoices: 'a six and a six; an eight and a six; a six and an eight; an eight and an eight'
+  CorrectAnswer: an eight and a six
+  AnswerTests: omnitest(correctVal = 'an eight and a six')
+
+- Class: text
+  Output: 'Next, we are going to start working with real data: estimates of world population (in thousands). A vector of data called "world.pop" has been loaded with this lesson. The first element is for the year 1950 up to the last element for 2010.'
+
+# Question 12
+- Class: cmd_question
+  Output: 'Check what "world.pop" refers to.'
   CorrectAnswer: 'world.pop'
   AnswerTests: any_of_exprs('world.pop', 'print(world.pop)')
   Hint: See 'Vectors'.
 
-# Question 9
+# Question 13
 - Class: cmd_question
-  Output: 'Use indexing to look at the 4th element of the vector.'
+  Output: 'Use indexing to look at the 4th element of the "world.pop" vector.'
   CorrectAnswer: 'world.pop[4]'
   AnswerTests: omnitest(correctExpr='world.pop[4]')
   Hint: See 'Vectors'.
 
-# Question 10  
+# Question 14
 - Class: cmd_question
-  Output: 'Use indexing and the concatenate function to call just the 1st and 4th elements of "world.pop".'
+  Output: 'Use indexing and concatenation to get just the 1st and 4th elements of "world.pop"'
   CorrectAnswer: 'world.pop[c(1,4)]'
   AnswerTests: any_of_exprs('world.pop[c(1,4)]', 'c(world.pop[1], world.pop[4])')
   Hint: See 'Vectors'.
@@ -106,23 +137,23 @@
 - Class: text
   Output: 'Next, we are going to practice using functions.'
 
-# Question 11
+# Question 15
 - Class: cmd_question
-  Output: 'How would you find the length (i.e., the number of elements) of the "world.pop" vector?'
+  Output: 'How would you find the length of i.e., the number of elements in, the "world.pop" vector?'
   CorrectAnswer: 'length(world.pop)'
   AnswerTests: omnitest(correctExpr='length(world.pop)')
   Hint: See 'Functions'.
 
-# Question 12
+# Question 16
 - Class: cmd_question
-  Output: 'Create a vector using the sequence function that goes from 1950 to 2010 by increments of 10. Assign this vector to an object called "year".'
+  Output: 'Create a vector using the sequence function that goes from 1950 to 2010 in increments of 10. Assign this vector to an object called "year".'
   CorrectAnswer: 'year <- seq(from = 1950, to = 2010, by = 10)'
   AnswerTests: any_of_exprs('year <- seq(from = 1950, to = 2010, by = 10)', 'year <- seq(1950, 2010, 10)')
   Hint: See 'Functions'.
 
-# Question 13
+# Question 17
 - Class: cmd_question
-  Output: 'Use the year vector just created to assign names to the "world.pop" vector.'
+  Output: 'Use the year vector just created to assign names to the elements of the "world.pop" vector.'
   CorrectAnswer: 'names(world.pop) <- year'
   AnswerTests: omnitest(correctExpr='names(world.pop) <- year')
   Hint: See 'Functions'.
@@ -130,20 +161,20 @@
 - Class: text
   Output: 'We have included a vector "x" in this lesson. This vector contains 10 integers from 0 to 100.'
 
-# Question 14
+# Question 18
 - Class: cmd_question
   Output: 'How would you replace the first element in "x" with a missing value?'
   CorrectAnswer: 'x[1] <- NA'
   AnswerTests: any_of_exprs('x[1] <- NA', 'x <- replace(x, 1, NA)')
   Hint: See 'Functions'.
 
-# Question 15 
+# Question 19
 - Class: mult_question
-  Output: 'What do you think R will return when we type "mean(x)"?' 
+  Output: 'What do you think R will return when we type "mean(x)"?'
   AnswerChoices: 'the average of the remaining numbers; the fifth highest number in "x"; a missing value'
   CorrectAnswer: a missing value
   AnswerTests: omnitest(correctVal = 'a missing value')
-  Hint: See 'Data Files'. 
+  Hint: See 'Data Files'.
 
 - Class: text
   Output: 'You''ve successfully completed part 1 of the Intro course!'

--- a/INTRO1/lesson.yaml
+++ b/INTRO1/lesson.yaml
@@ -70,7 +70,7 @@
   Output: 'Notice that spaces are allowed in character strings.'
 
 - Class: text
-  Output: 'We can also change what a name refers to by assigning a new object to the name.'
+  Output: 'We can also change what a name refers to by assigning a new object to it.'
 
 # Question 7
 - Class: cmd_question
@@ -80,30 +80,23 @@
   Hint: See 'Objects'.'
 
 - Class: text
-  Output: 'When we assign an existing object to a new name we make a copy.'
+  Output: 'When we assign an existing object to a new name we always make a copy of it.'
 
 # Question 8
 - Class: cmd_question
-  Output: 'Assign "result2" to "result".'
+  Output: 'Assign the value of "result" to "result2"'
   CorrectAnswer: 'result2 <- result'
   AnswerTests: omnitest(correctExpr='result2 <- result')
   Hint: See 'Objects'.'
 
 # Question 9
 - Class: cmd_question
-  Output: 'Now change "result" to be the value of 10 minus 2'
+  Output: 'Now make "result" name the value of 10 minus 2'
   CorrectAnswer: 'result <- 10 - 2'
   AnswerTests: omnitest(correctExpr='result <- 10 - 2')
   Hint: See 'Objects'.'
 
 # Question 10
-- Class: cmd_question
-  Output: 'What is the value of "result2"?'
-  CorrectAnswer: 'result2'
-  AnswerTests: omnitest(correctExpr='result2')
-  Hint: See 'Objects'.'
-
-# Question 11
 - Class: mult_question
   Output: 'What do you think R will return when we type "c(result, result2)"?'
   AnswerChoices: 'a six and a six; an eight and a six; a six and an eight; an eight and an eight'
@@ -113,21 +106,21 @@
 - Class: text
   Output: 'Next, we are going to start working with real data: estimates of world population (in thousands). A vector of data called "world.pop" has been loaded with this lesson. The first element is for the year 1950 up to the last element for 2010.'
 
-# Question 12
+# Question 11
 - Class: cmd_question
   Output: 'Check what "world.pop" refers to.'
   CorrectAnswer: 'world.pop'
   AnswerTests: any_of_exprs('world.pop', 'print(world.pop)')
   Hint: See 'Vectors'.
 
-# Question 13
+# Question 12
 - Class: cmd_question
   Output: 'Use indexing to look at the 4th element of the "world.pop" vector.'
   CorrectAnswer: 'world.pop[4]'
   AnswerTests: omnitest(correctExpr='world.pop[4]')
   Hint: See 'Vectors'.
 
-# Question 14
+# Question 13
 - Class: cmd_question
   Output: 'Use indexing and concatenation to get just the 1st and 4th elements of "world.pop"'
   CorrectAnswer: 'world.pop[c(1,4)]'
@@ -137,38 +130,38 @@
 - Class: text
   Output: 'Next, we are going to practice using functions.'
 
-# Question 15
+# Question 14
 - Class: cmd_question
   Output: 'How would you find the length of i.e., the number of elements in, the "world.pop" vector?'
   CorrectAnswer: 'length(world.pop)'
   AnswerTests: omnitest(correctExpr='length(world.pop)')
   Hint: See 'Functions'.
 
-# Question 16
+# Question 15
 - Class: cmd_question
   Output: 'Create a vector using the sequence function that goes from 1950 to 2010 in increments of 10. Assign this vector to an object called "year".'
   CorrectAnswer: 'year <- seq(from = 1950, to = 2010, by = 10)'
   AnswerTests: any_of_exprs('year <- seq(from = 1950, to = 2010, by = 10)', 'year <- seq(1950, 2010, 10)')
   Hint: See 'Functions'.
 
-# Question 17
+# Question 16
 - Class: cmd_question
-  Output: 'Use the year vector just created to assign names to the elements of the "world.pop" vector.'
+  Output: 'Use the "year" vector just created to give names to the elements of the "world.pop" vector.'
   CorrectAnswer: 'names(world.pop) <- year'
-  AnswerTests: omnitest(correctExpr='names(world.pop) <- year')
+  AnswerTests: any_of_exprs('names(world.pop) <- year', 'setNames(world.pop) <- year')
   Hint: See 'Functions'.
 
 - Class: text
   Output: 'We have included a vector "x" in this lesson. This vector contains 10 integers from 0 to 100.'
 
-# Question 18
+# Question 17
 - Class: cmd_question
   Output: 'How would you replace the first element in "x" with a missing value?'
   CorrectAnswer: 'x[1] <- NA'
   AnswerTests: any_of_exprs('x[1] <- NA', 'x <- replace(x, 1, NA)')
   Hint: See 'Functions'.
 
-# Question 19
+# Question 18
 - Class: mult_question
   Output: 'What do you think R will return when we type "mean(x)"?'
   AnswerChoices: 'the average of the remaining numbers; the fifth highest number in "x"; a missing value'

--- a/INTRO1/lesson.yaml
+++ b/INTRO1/lesson.yaml
@@ -171,3 +171,10 @@
 
 - Class: text
   Output: 'You''ve successfully completed part 1 of the Intro course!'
+
+- Class: mult_question
+  Output: Would you like to submit the log of this lesson?
+  AnswerChoices: Yes;No
+  CorrectAnswer: NULL
+  AnswerTests: submit_log()
+  Hint: hint

--- a/INTRO2/lesson.yaml
+++ b/INTRO2/lesson.yaml
@@ -18,7 +18,7 @@
 
 # Question 2
 - Class: cmd_question
-  Output: 'How would you multiply 2 by the quantity 9 plus 1?'
+  Output: 'How would you multiply 2 by the result of 9 plus 1?'
   CorrectAnswer: '2 * (9 + 1)'
   AnswerTests: any_of_exprs('2 * (9 + 1)', '(9 + 1) * 2')
   Hint: See 'Arithmetic Operations'.
@@ -28,31 +28,31 @@
 
 # Question 3
 - Class: cmd_question
-  Output: 'Create an object called "myobject" and assign the value 10 to it.'
+  Output: 'give the value 10 the name "myobject".'
   CorrectAnswer: 'myobject <- 10'
   AnswerTests: omnitest(correctExpr='myobject <- 10')
   Hint: See 'Objects'.
 
 # Question 4
 - Class: cmd_question
-  Output: 'Subtract 2 from "myobject" and assign it to the object "result".'
+  Output: 'Subtract 2 from "myobject" and call it "result".'
   CorrectAnswer: 'result <- myobject - 2'
   AnswerTests: omnitest(correctExpr = 'result <- myobject - 2')
-  Hint: See 'Objects'. 
+  Hint: See 'Objects'.
 
 # Question 5
 - Class: cmd_question
   Output: 'Use a function to find the class of "result".'
   CorrectAnswer: 'class(result)'
   AnswerTests: omnitest(correctExpr= 'class(result)')
-  Hint: See 'Objects'. 
+  Hint: See 'Objects'.
 
 # Question 6
 - Class: cmd_question
-  Output: 'Replace the object "myobject" with the character ''10''.'
+  Output: 'Reassign "myobject" to refer to the the characters ''10''.'
   CorrectAnswer: 'myobject <- "10"'
   AnswerTests: omnitest(correctExpr='myobject <- \'10\'')
-  Hint: See 'Objects'. 
+  Hint: See 'Objects'.
 
 # Question 7
 - Class: mult_question
@@ -74,10 +74,10 @@
 
 # Question 9
 - Class: cmd_question
-  Output: 'Find the maximum of "x".'
+  Output: 'Find the maximum value in "x".'
   CorrectAnswer: 'max(x)'
   AnswerTests: omnitest(correctExpr = 'max(x)')
-  Hint: See 'Functions'.  
+  Hint: See 'Functions'.
 
 - Class: text
   Output: 'A vector of data called "world.pop" has been loaded with this lesson. The first element is for the year 1950 up to the last element for 2010.'
@@ -87,7 +87,7 @@
 
 # Question 10
 - Class: cmd_question
-  Output: 'Divide each element of "world.pop" by 1000 and assign it to an object called "pop.million".'
+  Output: 'Divide each element of "world.pop" by 1000 and call that "pop.million".'
   CorrectAnswer: 'pop.million <- world.pop / 1000'
   AnswerTests: omnitest(correctExpr='pop.million <- world.pop / 1000')
   Hint: See 'Vectors'.
@@ -97,7 +97,7 @@
 
 # Question 11
 - Class: cmd_question
-  Output: 'Using "data_path", read in "data.csv" and assign it to a data frame object called "df".'
+  Output: 'Using "data_path", read in "data.csv" and as "df".  The first line of the file contains variable names'
   CorrectAnswer: 'df <- read.csv(data_path, header = TRUE)'
   AnswerTests: any_of_exprs('df <- read.csv(data_path, header = TRUE)', 'df <- read.csv(data_path, header = T)', 'df <- read.csv(data_path)')
   Hint: See 'Data Files'.
@@ -114,7 +114,7 @@
 
 # Question 13
 - Class: cmd_question
-  Output: 'Call the variable "world.pop" from the UNpop data frame.'
+  Output: 'Extract the variable "world.pop" from the "UNpop" data frame.'
   CorrectAnswer: 'UNpop$world.pop'
   AnswerTests: omnitest(correctExpr='UNpop$world.pop')
   Hint: See 'Data Files'.
@@ -128,7 +128,7 @@
 
 # Question 15
 - Class: cmd_question
-  Output: 'R uses a special character to denote comments. Use the "print()" function to write ''____ starts every comment''. Fill in the blank with the appropriate character.'
+  Output: 'R uses a special character to denote comments. Use the "print()" function to write ''_ starts every comment''. Replace _ with the appropriate character.'
   CorrectAnswer: 'print("# starts every comment")'
   AnswerTests: omnitest(correctExpr='print("# starts every comment")')
   Hint: See 'Data Files'.

--- a/INTRO2/lesson.yaml
+++ b/INTRO2/lesson.yaml
@@ -1,7 +1,7 @@
 - Class: meta
   Course: qss-swirl
   Lesson: INTRO2
-  Author: Elisha Cohen, Kosuke Imai
+  Author: Elisha Cohen, Kosuke Imai, Will Lowe
   Type: Standard
   Organization: Princeton University
   Version: 2.2.21
@@ -87,17 +87,24 @@
 
 # Question 10
 - Class: cmd_question
-  Output: 'Divide each element of "world.pop" by 1000 and call that "pop.million".'
+  Output: 'Divide each element of "world.pop" by 1000 and call the result "pop.million".'
   CorrectAnswer: 'pop.million <- world.pop / 1000'
   AnswerTests: omnitest(correctExpr='pop.million <- world.pop / 1000')
   Hint: See 'Vectors'.
 
 - Class: text
-  Output: 'Included in this lesson is a CSV data file called "data.csv". For convenience, we have assigned the path to "data.csv" to the object "data_path".'
+  Output: 'Included in this lesson is a CSV data file called "data.csv". For convenience, the file path to "data.csv" is called "data_path".'
 
 # Question 11
 - Class: cmd_question
-  Output: 'Using "data_path", read in "data.csv" and as "df".  The first line of the file contains variable names'
+  Output: 'Find the value of "data_path".'
+  CorrectAnswer: 'data_path'
+  AnswerTests: omnitest(correctExpr='data_path')
+  Hint: See 'Objects'.
+
+# Question 12
+- Class: cmd_question
+  Output: 'Using "data_path" as the path, read the content of the data file and call it "df".'
   CorrectAnswer: 'df <- read.csv(data_path, header = TRUE)'
   AnswerTests: any_of_exprs('df <- read.csv(data_path, header = TRUE)', 'df <- read.csv(data_path, header = T)', 'df <- read.csv(data_path)')
   Hint: See 'Data Files'.
@@ -105,35 +112,38 @@
 - Class: text
   Output: 'A data frame object called "UNpop" has already been included in this lesson.'
 
-# Question 12
+# Question 13
 - Class: cmd_question
   Output: 'What are the dimensions of "UNpop"?'
   CorrectAnswer: 'dim(UNpop)'
   AnswerTests: omnitest(correctExpr='dim(UNpop)')
   Hint: See 'Data Files'.
 
-# Question 13
+# Question 14
 - Class: cmd_question
   Output: 'Extract the variable "world.pop" from the "UNpop" data frame.'
   CorrectAnswer: 'UNpop$world.pop'
-  AnswerTests: omnitest(correctExpr='UNpop$world.pop')
+  AnswerTests: any_of_exprs('UNpop$world.pop', 'UNpop[,"world.pop"]')
   Hint: See 'Data Files'.
 
-# Question 14
+# Question 15
 - Class: cmd_question
   Output: 'Use indexing and/or the $ operator to look at the last four observations of the "year" variable from the "UNpop" data frame.'
   CorrectAnswer: 'UNpop$year[4:7]'
   AnswerTests: any_of_exprs('UNpop[4:7, "year"]', 'UNpop[4:7, 2]', 'UNpop$year[4:7]', 'UNpop[c(4:7), "year"]', 'UNpop[c(4:7), 2]', 'UNpop$year[c(4:7)]', 'UNpop$year[seq(from = 4, to = 7)]')
   Hint: See 'Data Files'.
 
-# Question 15
+- Class: text
+  Output: 'Notice that you have to quote the name of the variable if you index into "UNpop", but not if you use the dollar sign.'
+
+# Question 16
 - Class: cmd_question
-  Output: 'R uses a special character to denote comments. Use the "print()" function to write ''_ starts every comment''. Replace _ with the appropriate character.'
+  Output: 'R uses a special character to denote comments. Use the "print()" function to write ''X starts every comment''. Replace X with the appropriate character.'
   CorrectAnswer: 'print("# starts every comment")'
   AnswerTests: omnitest(correctExpr='print("# starts every comment")')
   Hint: See 'Data Files'.
 
-# Question 16
+# Question 17
 - Class: cmd_question
   Output: 'What would you type to load the R package "utils"?'
   CorrectAnswer: 'library(utils)'

--- a/qss-swirl.Rproj
+++ b/qss-swirl.Rproj
@@ -1,0 +1,16 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes

--- a/swirl2rnw.R
+++ b/swirl2rnw.R
@@ -1,0 +1,92 @@
+library(yaml)
+library(glue)
+
+## Alter these templates to change the output.
+##
+## Template notes:
+##   If the value of the template variable foo is bar then
+##   {foo} will be render as bar
+##   {{foo}} will render as {foo}
+##   {{{foo}}} will render as {bar}
+
+cmd_question <- "
+\\item {latex_escape(Output)}
+\\if1\\solutions
+\\newline\\newline \\noindent\\textbf{{Solution:}}
+<<eval=FALSE>>=
+{CorrectAnswer}
+@
+\\fi
+"
+mult_question <- "
+\\item {latex_escape(Output)}
+{enumerate_and_escape(AnswerChoices)}
+\\if1\\solutions
+\\newline\\newline \\noindent\\textbf{{Solution:}}
+\\begin{{verbatim}}
+{CorrectAnswer}
+\\end{{verbatim}}
+\\fi
+"
+rnw_template <- "
+\\section{{Swirl Review Questions}}
+\\subsection{{{Lesson}}}
+\\begin{{enumerate}}
+{Questions}
+\\end{{enumerate}}
+"
+
+latex_escape <- function(s){
+  # Adjusted from Simon Penel's stresc function in the seqinr package
+  s2c <- function(x){ unlist(strsplit(x, "")) }
+  fromchar <- c("\\", "{", "}", "$", "^", "_", "%", "#", "&", "~", "[", "]", "|")
+  tochar <- c("$\\backslash$", "\\{", "\\}", "\\$", "\\^{}", "\\_", "\\%",
+              "\\#", "\\&", "\\~{}", "\\lbrack{}", "\\rbrack{}","\\textbar{}")
+  translate <- function(x)
+    ifelse(x %in% fromchar, tochar[which(x == fromchar)], x)
+  val <- paste0(sapply(s2c(s), translate), collapse = "")
+  val <- gsub('"(.+?)"', "\\\\rexpr{\\1}", val, perl = TRUE)
+  val <- gsub('" R "', "\\\\R{}", val, fixed = TRUE)
+  val
+}
+
+enumerate_and_escape <- function(options){
+  opts <- lapply(trimws(unlist(strsplit(options, ";"))), latex_escape)
+  paste0("\\begin{enumerate}\n", paste("\\item", opts, collapse = "\n"),
+         "\n\\end{enumerate}")
+}
+
+process_question <- function(x){
+  switch(x$Class,
+         cmd_question = glue(cmd_question,
+                             Output = x$Output,
+                             CorrectAnswer = x$CorrectAnswer),
+         mult_question = glue(mult_question, Output = x$Output,
+                              CorrectAnswer = x$CorrectAnswer,
+                              AnswerChoices = x$AnswerChoices),
+         stop("Unrecognized question type", x$Class))
+}
+
+# bundle questions from multiple yaml files together and write a rnw fragment
+process_yaml_files <- function(yaml_files, rnw_filename, subsection){
+
+  yamls <- lapply(yaml_files, read_yaml)
+  bundle <- function(yaml){
+    qs <- Map(process_question,
+              Filter(function(x) grepl("question", x$Class), yaml))
+    paste(qs, collapse = "\n")
+  }
+  questions <- paste(sapply(yamls, bundle), collapse = "\n")
+  # meta <- Filter(function(x) x$Class == "meta", yamls[[1]])[[1]]
+  rnw <- glue(rnw_template, Lesson = subsection, Questions = questions)
+  writeLines(rnw, con = rnw_filename)
+}
+
+yamls <- dir(recursive = TRUE, full.names = TRUE, pattern = ".yaml")
+chapters <- c("PROBABILITY", "INTRO", "CAUSALITY", "PREDICTION", "DISCOVERY",
+              "UNCERTAINTY", "MEASUREMENT")
+for (ch in chapters)
+  process_yaml_files(yamls[grepl(ch, yamls)],
+                     rnw_filename = paste0(tolower(ch), "-swirl.rnw"),
+                     tools::toTitleCase(tolower(ch)))
+


### PR DESCRIPTION
This PR changes does three things:

1. Corrects some misleading language about assignment and quoting
2. Adds a couple of questions exploring R's copy on assignment semantics
3. Provides `swirl2rnw.R` is (hopefully) a drop in replacement for `swirl2rnw` that does not require a working shell and is significantly easier to adjust. 

### Notes on `swirl2rnw.R`

The loop at the end of the file creates `swirl-<chaptername>.rnw` files. Source the file to make them all.

Files may not generate exactly the same latex as `swirl2rnw`, partly because I couldn't always figure out what the shell script was doing.

To *change* the way `swirl2rnw.R` represents questions and solutions in latex, just change the template fragments at the top of the file. 

Example: in `swirl2rnw.R`, textual multiple choice solutions are presented in a `verbatim` block rather than as unevaluated R in a Sweave code block. If you want the old style back then just change the relevant template - `mult_question` in this case - from having
```
\\begin{{verbatim}}
{CorrectAnswer}
\\end{{verbatim}}
```
to having
```
<<eval=FALSE>>=
{CorrectAnswer}
@
```
