### PR TITLE
Accepting additional legitimate answers

### DIFF
--- a/CAUSALITY1/lesson.yaml
+++ b/CAUSALITY1/lesson.yaml
@@ -13,7 +13,10 @@
 # Introduction #
 ################
 - Class: text
-  Output: 'These exercises are a companion to Chapter 2 of ''Quantitative Social Science: Introduction''. When you see ..., press Enter.'
+  Output: >
+    These exercises are a companion to Chapter 2 of
+    'Quantitative Social Science: Introduction'.
+    When you see ..., press Enter.'
 
 ## Conceptual Questions
 # Question 1
@@ -38,7 +41,7 @@
 # Question 3
 - Class: cmd_question
   Output: >
-    Translate the following statement using R''s logical values
+    Translate the following statement using R's logical values
     (i.e., "TRUE" and "FALSE") and operators (i.e., !, =, &, and |):
     True or false is not false.
   CorrectAnswer: (TRUE | FALSE) == !FALSE
@@ -77,7 +80,7 @@
 - Class: text
   Output: >
     A variety of external data files can be loaded into R,
-    such as tables with comma separated values (or CSV''s)
+    such as tables with comma separated values (or CSV's)
     and R Workspace files (RData files).
 
 # Question 1
@@ -124,7 +127,7 @@
     "resume" contains two binary variables, "sex" and "call".
     Create a table that compares the number of female applicants to the number
     of male applicants who did and did not receive a call back.
-    Be sure to label the rows as ''sex'' and the columns as ''call''.
+    Be sure to label the rows as 'sex' and the columns as 'call'.
   CorrectAnswer: table(sex = resume$sex, call = resume$call)
   AnswerTests: >-
     any_of_exprs(

--- a/CAUSALITY1/lesson.yaml
+++ b/CAUSALITY1/lesson.yaml
@@ -18,7 +18,10 @@
 ## Conceptual Questions
 # Question 1
 - Class: mult_question
-  Output: 'Suppose a variable is binary, that is, it takes on values of either 0 or 1 (for example, female gender). Which of the following is the same as its sample mean?'
+  Output: >
+    Suppose a variable is binary, that is, it takes on values of either 0 or 1
+    (for example, female gender).
+    Which of the following is the same as its sample mean?
   AnswerChoices: 'the sample median; the sample rate of 1''s; neither of these'
   CorrectAnswer: the sample rate of 1's
   AnswerTests: omnitest(correctVal="the sample rate of 1's")
@@ -34,14 +37,27 @@
 
 # Question 3
 - Class: cmd_question
-  Output: 'Translate the following statement using R''s logical values (i.e., "TRUE" and "FALSE") and operators (i.e., !, =, &, and |): True or false is not false.'
+  Output: >
+    Translate the following statement using R''s logical values
+    (i.e., "TRUE" and "FALSE") and operators (i.e., !, =, &, and |):
+    True or false is not false.
   CorrectAnswer: (TRUE | FALSE) == !FALSE
-  AnswerTests: any_of_exprs("(TRUE | FALSE) == !FALSE", "TRUE | FALSE == !FALSE", "TRUE | FALSE != FALSE", "(TRUE | FALSE) != FALSE", "T|F != F", "(T|F) != F", "T|F == !F", "(T|F) == !F")
-  Hint: 'See ''Subsetting the Data in R'' (and be sure you use proper capitalization and spacing!).'
+  AnswerTests: >-
+    any_of_exprs(
+      "(TRUE | FALSE) == !FALSE", "TRUE | FALSE == !FALSE",
+      "TRUE | FALSE != FALSE", "(TRUE | FALSE) != FALSE",
+      "T|F != F", "(T|F) != F", "T|F == !F", "(T|F) == !F"
+    )
+  Hint: >
+    See 'Subsetting the Data in R'
+    (and be sure you use proper capitalization and spacing!).
 
 # Question 4
 - Class: mult_question
-  Output: 'In order to calculate the mean of a variable we have used the "length()" function in the denominator. The "length()" of a vector is equivalent to __________'
+  Output: >
+    In order to calculate the mean of a variable we have used the "length()"
+    function in the denominator.
+    The "length()" of a vector is equivalent to __________
   AnswerChoices: 'the number of elements; the height; the maximum'
   CorrectAnswer: the number of elements
   AnswerTests: omnitest(correctVal='the number of elements')
@@ -50,20 +66,28 @@
 # Question 5
 - Class: mult_question
   Output: 'How are factor variables different from categorical variables?'
-  AnswerChoices: 'They are the same; Factor variables contain numeric values; Categorical variables tend to have more levels or categories'
+  AnswerChoices: >
+    They are the same; Factor variables contain numeric values;
+    Categorical variables tend to have more levels or categories
   CorrectAnswer: They are the same
   AnswerTests: omnitest(correctVal='They are the same')
   Hint: 'See ''Subsetting the Data in R''.'
 
 ## Programming questions
 - Class: text
-  Output: 'A variety of external data files can be loaded into R, such as tables with comma separated values (or CSV''s) and R Workspace files (RData files).' 
+  Output: >
+    A variety of external data files can be loaded into R,
+    such as tables with comma separated values (or CSV''s)
+    and R Workspace files (RData files).
 
 # Question 1
 - Class: cmd_question
-  Output: 'Using the read.csv() function, we have pre-loaded the external data file "resume.csv" as an object called "resume". Call the head() function to look at the first six rows of "resume".'
+  Output: >
+    Using the read.csv() function, we have pre-loaded the external data file
+    "resume.csv" as an object called "resume". Call the head() function to look
+    at the first six rows of "resume".
   CorrectAnswer: head(resume)
-  AnswerTests: omnitest(correctExpr="head(resume)")
+  AnswerTests: any_of_exprs("head(resume)", "head(resume, 6)")
   Hint: 'See ''Data Files'' in Chapter 1.'
 
 # Question 2
@@ -75,14 +99,20 @@
 
 # Question 3
 - Class: cmd_question
-  Output: 'This question has two parts. First, create a summary of "resume" that contains, along with other information, the sample means of each variable in "resume".'
+  Output: >
+    This question has two parts. First, create a summary of "resume" that
+    contains, along with other information, the sample means of each variable
+    in "resume".
   CorrectAnswer: summary(resume)
   AnswerTests: omnitest(correctExpr="summary(resume)")
   Hint: 'See ''Racial Discrimination in the Labor Market''.'
 
 # Question 4
 - Class: mult_question
-  Output: 'Second, looking at the summary of "resume", what was the callback rate in the data? In other words, about what percent of the fictitious applicants received a call back?'
+  Output: >
+    Second, looking at the summary of "resume", what was the callback rate
+    in the data? In other words, about what percent of the fictitious applicants
+    received a call back?
   AnswerChoices: '2%; 16%; 8%; 9%'
   CorrectAnswer: 8%
   AnswerTests: omnitest(correctVal="8%")
@@ -90,9 +120,17 @@
 
 # Question 5
 - Class: cmd_question
-  Output: '"resume" contains two binary variables, "sex" and "call". Create a table that compares the number of female applicants to the number of male applicants who did and did not receive a call back. Be sure to label the rows as ''sex'' and the columns as ''call''.'
+  Output: >
+    "resume" contains two binary variables, "sex" and "call".
+    Create a table that compares the number of female applicants to the number
+    of male applicants who did and did not receive a call back.
+    Be sure to label the rows as ''sex'' and the columns as ''call''.
   CorrectAnswer: table(sex = resume$sex, call = resume$call)
-  AnswerTests: omnitest(correctExpr="table(sex = resume$sex, call = resume$call)")
+  AnswerTests: >-
+    any_of_exprs(
+      "table(sex = resume$sex, call = resume$call)",
+      "with(resume, table(sex = sex, call = call))"
+    )
   Hint: 'See ''Racial Discrimination in the Labor Market''.'
 
 - Class: text

--- a/CAUSALITY1/lesson.yaml
+++ b/CAUSALITY1/lesson.yaml
@@ -134,4 +134,5 @@
   Hint: 'See ''Racial Discrimination in the Labor Market''.'
 
 - Class: text
-  Output: 'You''ve successfully completed part 1 of the Causality course!'
+  Output: >
+    You've successfully completed part 1 of the Causality course!

--- a/CAUSALITY2/lesson.yaml
+++ b/CAUSALITY2/lesson.yaml
@@ -13,35 +13,60 @@
 # Introduction #
 ################
 - Class: text
-  Output: 'These exercises are a companion to Chapter 2 of ``Quantitative Social Science: Introduction''.'
+  Output: >
+    These exercises are a companion to Chapter 2 of
+    'Quantitative Social Science: Introduction'.
 
 ## Conceptual Questions
 # Question 1
 - Class: mult_question
-  Output: 'Chapter 2 discusses several approaches to identifying causal relationships. Which of the following approaches is considered the ''gold standard'' in many scientific disciplines?'
-  AnswerChoices: 'Randomized controlled trials; Randomized experiments; Either of these'
+  Output: >
+    Chapter 2 discusses several approaches to identifying causal relationships.
+    Which of the following approaches is considered the 'gold standard'
+    in many scientific disciplines?
+  AnswerChoices: >
+    Randomized controlled trials; Randomized experiments; Either of these
   CorrectAnswer: Either of these
   AnswerTests: omnitest(correctVal="Either of these")
-  Hint: 'Don''t be confused by the different terminology! See ''Randomized Controlled Trials''.'
+  Hint: >
+    Don't be confused by the different terminology!
+    See Randomized Controlled Trials'.
 
 - Class: text
-  Output: 'For ethical and logistical reasons, social scientists are often unable to conduct randomized controlled trials (RCTs). Therefore, they must conduct observational studies in which data on naturally occurring events are collected and analyzed.'
+  Output: >
+    For ethical and logistical reasons, social scientists are often unable
+    to conduct randomized controlled trials (RCTs). Therefore, they must conduct
+    observational studies in which data on naturally occurring events are
+    collected and analyzed.
 
 # Question 2
 - Class: mult_question
-  Output: 'With observational studies, it is often hard to establish that changes in one variable caused changes in another variable. In other words, observational studies have less __________ compared to RCTS.'
-  AnswerChoices: 'Internal validity; External validity; Generalizability; All of these'
+  Output: >
+    With observational studies, it is often hard to establish that changes in
+    one variable caused changes in another variable. In other words,
+    observational studies have less __________ compared to RCTS.
+  AnswerChoices: >
+    Internal validity; External validity; Generalizability; All of these
   CorrectAnswer: Internal validity
   AnswerTests: omnitest(correctVal="Internal validity")
   Hint: 'See ''The Role of Randomization''.'
 
 - Class: text
-  Output: 'Take a look at the following nested "ifelse()" statement: "social$type <- ifelse(social$yearofbirth <= 1943 & social$primary2004 == 1, ''Senior Voter'', ifelse(social$yearofbirth <= 1943 & social$primary2004 == 0, ''Senior Non-voter'', ifelse(social$yearofbirth > 1943 & social$primary2004 == 1, ''Non-senior Voter'', ''Non-senior Non-voter'')))"'
+  Output: >
+    Take a look at the following nested "ifelse()" statement:
+    "social$type <- ifelse(social$yearofbirth <= 1943 & social$primary2004 == 1,
+    ''Senior Voter'',
+    ifelse(social$yearofbirth <= 1943 & social$primary2004 == 0,
+    ''Senior Non-voter'',
+    ifelse(social$yearofbirth > 1943 & social$primary2004 == 1,
+    ''Non-senior Voter'', ''Non-senior Non-voter'')))"
 
 # Question 3
 - Class: mult_question
   Output: 'What kinds of people does "social$type" distinguish between?'
-  AnswerChoices: 'seniors and non-seniors; voters and non-voters; non-senior voters and non-senior non-voters; all of these'
+  AnswerChoices: >
+    seniors and non-seniors; voters and non-voters;
+    non-senior voters and non-senior non-voters; all of these
   CorrectAnswer: all of these
   AnswerTests: omnitest(correctVal="all of these")
   Hint: 'See "Simple Conditional Statements".'
@@ -49,9 +74,15 @@
 # Question 4
 - Class: mult_question
   Output: 'The counterfactual is __________.'
-  AnswerChoices: 'what actually happened; what would have happened if a key condition were different; what we want to happen'
+  AnswerChoices: >
+    what actually happened;
+    what would have happened if a key condition were different;
+    what we want to happen
   CorrectAnswer: what would have happened if a key condition were different
-  AnswerTests: omnitest(correctVal="what would have happened if a key condition were different")
+  AnswerTests: >-
+    omnitest(
+      correctVal = "what would have happened if a key condition were different"
+    )
   Hint: See 'Causal Effects and the Counterfactual'.
 
 # Question 5
@@ -64,23 +95,43 @@
 
 ## Programming Questions
 - Class: text
-  Output: 'The external data file "resume.csv" has been loaded for you as the data frame object "resume". Be sure that you have read the section ''Racial Discrimination in the Labor Market'' and understand what this data file contains.'
+  Output: >
+    The external data file "resume.csv" has been loaded for you as the data
+    frame object "resume". Be sure that you have read the section
+    'Racial Discrimination in the Labor Market' and understand
+    what this data file contains.
 
 # Question 6
 - Class: cmd_question
-  Output: 'Use indexing to find the callback rate for fictitious female job applicants in "resume".'
+  Output: >
+    Use indexing to find the callback rate for fictitious female job applicants
+    in "resume".
   CorrectAnswer: mean(resume$call[resume$sex == "female"])
-  AnswerTests: any_of_exprs('mean(resume$call[resume$sex == "female"])', 'mean(resume[resume$sex == "female", "call"])', 'mean(resume[resume[, "sex"] == "female", "call"])')
+  AnswerTests: >-
+    any_of_exprs(
+      'mean(resume$call[resume$sex == "female"])',
+      'mean(resume[resume$sex == "female", "call"])',
+      'mean(resume[resume[, "sex"] == "female", "call"])'
+    )
   Hint: 'See ''Subsetting the Data in R''.'
 
 - Class: text
-  Output: 'We can also find the callback rate for fictitious female job applicants using the "subset()" function.'
+  Output: >
+    We can also find the callback rate for fictitious female job applicants
+    using the "subset()" function.
 
 # Question 7
 - Class: cmd_question
-  Output: 'To find the result of Question 6 through a different method, use "subset()" to create a new data frame object called "resumeF" that only consists of female applicants.'
+  Output: >
+    To find the result of Question 6 through a different method,
+    use "subset()" to create a new data.frame object called "resumeF" that
+    only consists of female applicants.
   CorrectAnswer: resumeF <- subset(resume, sex == "female")
-  AnswerTests: any_of_exprs('resumeF <- subset(resume, sex == "female")', 'resumeF <- subset(resume, subset = (sex == "female"))')
+  AnswerTests: >-
+    any_of_exprs(
+      'resumeF <- subset(resume, sex == "female")',
+      'resumeF <- subset(resume, subset = (sex == "female"))'
+    )
   Hint: 'See ''Subsetting the Data in R''.'
 
 # Question 8
@@ -91,30 +142,61 @@
   Hint: 'See ''Subsetting the Data in R''.'
 
 - Class: text
-  Output: 'The external data file "social.csv" has been loaded for you as the data.frame object "social". Be sure that you have read the section ''Social Pressure and Voter Turnout'' and understand what this data file contains.'
+  Output: >
+    The external data file "social.csv" has been loaded for you as the
+    data.frame object "social". Be sure that you have read the section
+    'Social Pressure and Voter Turnout' and understand what this data file
+    contains.
 
 - Class: text
-  Output: 'Recall that the "tapply()" function takes three arguments, in order, "X", "INDEX", and "FUN". You can think of "tapply()" as taking an object (typically a vector) called "X"; splitting "X" into categories defined by "INDEX"; and, lastly, applying the "FUN"-ction to each subset of "X".'
+  Output: >
+    Recall that the "tapply()" function takes three arguments,
+    in order, "X", "INDEX", and "FUN". You can think of "tapply()"
+    as taking an object (typically a vector) called "X"; splitting "X"
+    into categories defined by "INDEX"; and, lastly, applying the "FUN"-ction
+    to each subset of "X".
 
 # Question 9
 - Class: cmd_question
-  Output: 'Try using "tapply()" to find the turnout rate in 2006 for each experimental group identified by the variable "messages".'
+  Output: >
+    Try using "tapply()" to find the turnout rate in 2006 for each experimental
+    group identified by the variable "messages".
   CorrectAnswer: tapply(social$primary2006, social$messages, mean)
-  AnswerTests: any_of_exprs('tapply(social$primary2006, social$messages, mean)', 'tapply(social[, "primary2006"], social[, "messages"], mean)', 'tapply(social$primary2006, social[, "messages"], mean)', 'tapply(social[, "primary2006"], social$messages, mean)')
+  AnswerTests: >-
+    any_of_exprs(
+      'tapply(social$primary2006, social$messages, mean)',
+      'tapply(social[, "primary2006"], social[, "messages"], mean)',
+      'tapply(social$primary2006, social[, "messages"], mean)',
+      'tapply(social[, "primary2006"], social$messages, mean)'
+    )
   Hint: 'See ''Social Pressure and Voter Turnout''.'
 
 - Class: text
-  Output: 'Recall that the "ifelse()" function takes three arguments. The first argument is a logical statement that can either be "TRUE" or "FALSE". If it is "TRUE", "ifelse()" returns the second argument. If it is "FALSE", "ifelse()" returns the third argument.'
+  Output: >
+    Recall that the "ifelse()" function takes three arguments.
+    The first argument is a logical statement that can either be "TRUE" or
+    "FALSE". If it is "TRUE", "ifelse()" returns the second argument.
+    If it is "FALSE", "ifelse()" returns the third argument.
 
 - Class: text
-  Output: 'We will now use the "ifelse()" function to recode sex as a numeric variable.'
+  Output: >
+    We will now use the "ifelse()" function to recode sex as a numeric variable.
 
 # Question 10
 - Class: cmd_question
-  Output: 'Use "ifelse()" to create a new variable, "social$female", that equals 1 if the applicant is female and 0 otherwise.'
+  Output: >
+    Use "ifelse()" to create a new variable, "social$female", that equals 1
+    if the applicant is female and 0 otherwise.
   CorrectAnswer: social$female <- ifelse(social$sex == "female", 1, 0)
-  AnswerTests: any_of_exprs('social$female <- ifelse(social$sex == "female", 1, 0)', 'social$female <- ifelse(social$sex == "male", 0, 1)', 'social$female <- ifelse(social[, "sex"] == "female", 1, 0)', 'social$female <- ifelse(social[, "sex"] == "male", 0, 1)')
+  AnswerTests: >-
+    any_of_exprs(
+      'social$female <- ifelse(social$sex == "female", 1, 0)',
+      'social$female <- ifelse(social$sex == "male", 0, 1)',
+      'social$female <- ifelse(social[, "sex"] == "female", 1, 0)',
+      'social$female <- ifelse(social[, "sex"] == "male", 0, 1)'
+    )
   Hint: 'See ''Simple Conditional Statements''.'
 
 - Class: text
-  Output: 'You''ve successfully completed part 2 of the Causality course!'
+  Output: >
+    You've successfully completed part 2 of the Causality course!

--- a/CAUSALITY2/lesson.yaml
+++ b/CAUSALITY2/lesson.yaml
@@ -55,11 +55,12 @@
   Output: >
     Take a look at the following nested "ifelse()" statement:
     "social$type <- ifelse(social$yearofbirth <= 1943 & social$primary2004 == 1,
-    ''Senior Voter'',
+    'Senior Voter',
     ifelse(social$yearofbirth <= 1943 & social$primary2004 == 0,
-    ''Senior Non-voter'',
+    'Senior Non-voter',
     ifelse(social$yearofbirth > 1943 & social$primary2004 == 1,
-    ''Non-senior Voter'', ''Non-senior Non-voter'')))"
+    'Non-senior Voter',
+    'Non-senior Non-voter')))"
 
 # Question 3
 - Class: mult_question

--- a/CAUSALITY2/lesson.yaml
+++ b/CAUSALITY2/lesson.yaml
@@ -110,10 +110,15 @@
   AnswerTests: >-
     any_of_exprs(
       'mean(resume$call[resume$sex == "female"])',
+      'mean(resume[resume$sex == "female", ]$call)',
       'mean(resume[resume$sex == "female", "call"])',
-      'mean(resume[resume[, "sex"] == "female", "call"])'
+      'mean(resume[resume[, "sex"] == "female", "call"])',
+      'mean(resume$call[resume[, "sex"] == "female"])',
+      'mean(resume[resume[, "sex"] == "female", ]$call)'
     )
-  Hint: 'See ''Subsetting the Data in R''.'
+  Hint: >
+    See Subsetting the Data in R'.
+    Remember to use indexing instead of "subset()".
 
 - Class: text
   Output: >

--- a/DISCOVERY1/lesson.yaml
+++ b/DISCOVERY1/lesson.yaml
@@ -14,47 +14,76 @@
 #################
 ## Conceptual Questions
 - Class: text
-  Output: 'These exercises are a companion to Chapter 5 of ''A First Course in Quantitative Social Science''. When you see ..., press Enter.'
+  Output: >-
+    These exercises are a companion to Chapter 5 of
+    'Quantitative Social Science'. When you see ..., press Enter.
 
 - Class: text
-  Output: 'Chapter 5 introduces many concepts related to discovery, one of which is ''unsupervised learning''.'
+  Output: >
+    Chapter 5 introduces many concepts related to discovery,
+    one of which is 'unsupervised learning'.
 
 # Question 1
 - Class: mult_question
   Output: 'What is an example of an ''unsupervised learning'' problem?'
-  AnswerChoices: 'Finding topics in a set of newspaper articles; Discovering ideological differences among legislators; Identifying commonly used words in an author''s corpus; All of these'
+  AnswerChoices: >
+    Finding topics in a set of newspaper articles;
+    Discovering ideological differences among legislators;
+    Identifying commonly used words in an author's corpus; All of these
   CorrectAnswer: All of these
   AnswerTests: omnitest(correctVal = "All of these")
-  Hint: See Chapter 5. 
+  Hint: See Chapter 5.
 
 # Question 2
 - Class: mult_question
-  Output: 'How did unsupervised learning enable researchers to address the disputed authorship of the Federalist Papers?'
-  AnswerChoices: 'Hamilton and Madison preferred to discuss different topics; Hamilton and Madison favored different words; Madison left coded messages in his prose; All of these'
+  Output: >
+    How did unsupervised learning enable researchers to address the disputed
+    authorship of the Federalist Papers?
+  AnswerChoices: >
+    Hamilton and Madison preferred to discuss different topics;
+    Hamilton and Madison favored different words;
+    Madison left coded messages in his prose; All of these
   CorrectAnswer: Hamilton and Madison favored different words
-  AnswerTests: omnitest(correctVal = 'Hamilton and Madison favored different words')
+  AnswerTests: >-
+    omnitest(correctVal = 'Hamilton and Madison favored different words')
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
 # Question 3
 - Class: mult_question
-  Output: 'What kind of information does a document-term matrix like "dtm" contain?'
-  AnswerChoices: 'Term frequencies across a set of documents; The number of times a word is used in a document; The number of documents that contain a word at least once; All of these'
+  Output: >
+    What kind of information does a document-term matrix like "dtm" contain?
+  AnswerChoices: >
+    Term frequencies across a set of documents;
+    The number of times a word is used in a document;
+    The number of documents that contain a word at least once; All of these
   CorrectAnswer: All of these
   AnswerTests: omnitest(correctVal = "All of these")
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
 # Question 4
 - Class: mult_question
-  Output: 'Why does working with a document-term matrix require us to make the ''bag-of-words'' assumption?'
-  AnswerChoices: 'A document-term matrix says nothing about grammar or order of words; A document-term matrix contains a lot of words; A document-term matrix sorts similar words into bags; None of these'
-  CorrectAnswer: A document-term matrix says nothing about grammar or order of words
-  AnswerTests: omnitest(correctVal = 'A document-term matrix says nothing about grammar or order of words')
+  Output: >
+    Why does working with a document-term matrix require us to make the
+    'bag-of-words' assumption?'
+  AnswerChoices: >
+    A document-term matrix says nothing about grammar or order of words;
+    A document-term matrix contains a lot of words;
+    A document-term matrix sorts similar words into bags; None of these
+  CorrectAnswer: >
+    A document-term matrix says nothing about grammar or order of words
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'A document-term matrix says nothing about grammar or order of words'
+    )
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
 ## Programming Questions
 # Question 5
 - Class: cmd_question
-  Output: 'Chapter 5 also introduces several important R extensions, or packages. Use the "install.packages()" function to install the "wordcloud" package.'
+  Output: >
+    Chapter 5 also introduces several important R extensions, or packages.
+    Use the "install.packages()" function to install the "wordcloud" package.
   CorrectAnswer: install.packages("wordcloud")
   AnswerTests: omnitest(correctExpr = 'install.packages("wordcloud")')
 
@@ -65,37 +94,62 @@
   AnswerTests: any_of_exprs('library(wordcloud)', 'library("wordcloud")')
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
-- Class: text 
-  Output: 'We will use the "wordcloud" package to visualize a document-term matrix called "dtm", which has already been loaded for you.'
+- Class: text
+  Output: >
+    We will use the "wordcloud" package to visualize a document-term matrix
+    called "dtm", which has already been loaded for you.
 
 # Question 7
 - Class: cmd_question
-  Output: 'Use the "inspect()" function to visualize the first 5 rows and 8 columns of "dtm".'
+  Output: >
+    Use the "inspect()" function to visualize the first 5 rows and 8 columns of
+    "dtm".
   CorrectAnswer: inspect(dtm[1:5, 1:8])
-  AnswerTests: omnitest(correctExpr='inspect(dtm[1:5, 1:8])')
+  AnswerTests: >-
+    any_of_exprs(
+      'inspect(dtm[1:5, 1:8])',
+      'inspect(dtm[seq(5), seq(8)])',
+      'inspect(dtm[1:5, seq(8)])',
+      'inspect(dtm[seq(5), 1:8])'
+    )
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
 # Question 8
 - Class: cmd_question
-  Output: 'Currently, "dtm" belongs to a special R class called "DocumentTermMatrix". This object class is not easily manipulated in R. Using the as.matrix() function, coerce "dtm" to a matrix object in R called "dtm.mat".'
+  Output: >
+    Currently, "dtm" belongs to a special R class called "DocumentTermMatrix".
+    This object class is not easily manipulated in R.
+    Using the as.matrix() function, coerce "dtm" to a matrix object in R
+    called "dtm.mat".
   CorrectAnswer: dtm.mat <- as.matrix(dtm)
   AnswerTests: omnitest(correctExpr = "dtm.mat <- as.matrix(dtm)")
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
 # Question 9
 - Class: cmd_question
-  Output: 'Finally, use the wordcloud() function to visualize the information contained in the eighth document of "dtm.mat" only.'
+  Output: >
+    Finally, use the wordcloud() function to visualize the information contained
+    in the eighth document of "dtm.mat" only.
   CorrectAnswer: wordcloud(colnames(dtm.mat), dtm.mat[8, ])
-  AnswerTests: omnitest(correctExpr = 'wordcloud(colnames(dtm.mat), dtm.mat[8, ])')
+  AnswerTests: >-
+    omnitest(correctExpr = 'wordcloud(colnames(dtm.mat), dtm.mat[8, ])')
   Hint: See 'The Disputed Authorship of The Federalist Papers'.
 
 # Question 10
 - Class: mult_question
-  Output: 'Which of these do you think best describes the topic of the eighth Federalist Paper?'
-  AnswerChoices: 'The costs and benefits of standing militia; Trade between the colonies; The universal rights of man; The abolition of slavery'
+  Output: >
+    Which of these do you think best describes the topic of the eighth
+    Federalist Paper?
+  AnswerChoices: >
+    The costs and benefits of standing militia;
+    Trade between the colonies;
+    The universal rights of man;
+    The abolition of slavery
   CorrectAnswer: The costs and benefits of standing militia
-  AnswerTests: omnitest(correctVal = "The costs and benefits of standing militia")
+  AnswerTests: >-
+    omnitest(correctVal = "The costs and benefits of standing militia")
 
 - Class: text
-  Output: 'You''ve successfully completed part 1 of the Discovery course!'
+  Output: >
+    You've successfully completed part 1 of the Discovery course!
 

--- a/DISCOVERY2/lesson.yaml
+++ b/DISCOVERY2/lesson.yaml
@@ -11,18 +11,24 @@
 
 ## Conceptual Questions
 - Class: text
-  Output: 'These exercises are a companion to Chapter 5 of ''A First Course in Quantitative Social Science''. When you see ..., press Enter.'
+  Output: >
+    These exercises are a companion to Chapter 5 of
+    'Quantitative Social Science'. When you see ..., press Enter.
 
 - Class: text
-  Output: 'Chapter 5 also introduces tools for analyzing network data, which describe the relationships between units.'
+  Output: >
+    Chapter 5 also introduces tools for analyzing network data,
+    which describe the relationships between units.
 
 # Question 1
 - Class: mult_question
   Output: 'What are some examples of networks?'
-  AnswerChoices: 'marriages between families; international trade flows; friendships on Facebook; all of these'
+  AnswerChoices: >
+    marriages between families;international trade flows;
+    friendships on Facebook; all of these
   CorrectAnswer: all of these
   AnswerTests: omnitest(correctVal = "all of these")
-  Hint: See ''Network Data''. 
+  Hint: See ''Network Data''.
 
 # Question 2
 - Class: mult_question
@@ -35,95 +41,159 @@
 # Question 3
 - Class: mult_question
   Output: 'An edge represents the __________'
-  AnswerChoices: 'existence of a relationship between any pair of nodes; lack of a relationship between any pair of nodes; nodes that are the same'
+  AnswerChoices: >
+    existence of a relationship between any pair of nodes;
+    lack of a relationship between any pair of nodes; nodes that are the same
   CorrectAnswer: existence of a relationship between any pair of nodes
-  AnswerTests: omnitest(correctVal = 'existence of a relationship between any pair of nodes')
+  AnswerTests: >-
+    omnitest(
+      correctVal = 'existence of a relationship between any pair of nodes'
+    )
   Hint: See 'Undirected Graphs and Centrality Measures'.
 
 ## Programming Questions
 - Class: text
-  Output: 'Network data often take the form of an adjacency matrix. Adjacency matrices have the same number of rows and columns, and each row (column) corresponds to a unit. Each cell describes the relationship between a pair of units, and each diagonal cell describes the relationship of a unit with itself.' 
+  Output: >
+    Network data often take the form of an adjacency matrix.
+    Adjacency matrices have the same number of rows and columns,
+    and each row (column) corresponds to a unit.
+    Each cell describes the relationship between a pair of units,
+    and each diagonal cell describes the relationship of a unit with itself.
 
 - Class: text
-  Output: 'Let''s explore the adjacency matrix "florence" described in Chapter 5. "florence" has already been loaded for you.'
+  Output: >
+    Let's explore the adjacency matrix "florence" described in Chapter 5.
+    "florence" has already been loaded for you.
 
 # Question 4
 - Class: cmd_question
-  Output: 'Verify that "florence" is a square adjacency matrix using the dim() function.'
+  Output: >
+    Verify that "florence" is a square adjacency matrix using the dim()
+    function.
   CorrectAnswer: dim(florence)
   AnswerTests: omnitest(correctExpr = "dim(florence)")
 
 # Question 5
 - Class: cmd_question
-  Output: 'Now, use indexing to have R output the adjacency (sub)matrix for the first 5 families only.'
+  Output: >
+    Now, use indexing to have R output the adjacency (sub)matrix
+    for the first 5 families only.
   CorrectAnswer: florence[1:5, 1:5]
-  AnswerTests: omnitest(correctExpr = "florence[1:5, 1:5]")
-  Hint: See ''Marriage Network in Renaissance Florence''. 
+  AnswerTests: >
+    any_of_exprs(
+      "florence[1:5, 1:5]",
+      "florence[1:5, seq(5)]",
+      "florence[seq(5), 1:5]",
+      "florence[seq(5), seq(5)]"
+    )
+  Hint: See ''Marriage Network in Renaissance Florence''.
 
 # Question 6
 - Class: mult_question
   Output: 'Is "florence" an example of directed or undirected network data?'
-  AnswerChoices: 'florence is undirected; florence is directed; we cannot tell yet'
+  AnswerChoices: >
+    florence is undirected; florence is directed; we cannot tell yet
   CorrectAnswer: florence is undirected
   AnswerTests: omnitest(correctVal = 'florence is undirected')
-  Hint: See 'Marriage Network in Renaissance Florence'. 
+  Hint: See 'Marriage Network in Renaissance Florence'.
 
 - Class: text
-  Output: 'Let''s try visualizing "florence" using a graph. We''ve already installed the igraph package for you to use.'
+  Output: >
+    Let's try visualizing "florence" using a graph.
+    We've already installed the igraph package for you to use.
 
 # Question 7
-- Class: cmd_question 
-  Output: 'There are two steps to plotting the network graph of "florence". First, use graph.adjacency() function to produce an "igraph" object called "florence.graph". Be sure to specify that the adjancency matrix is undirected and that there are no marriages within families.'
-  CorrectAnswer: florence.graph <- graph.adjacency(florence, mode = "undirected", diag = FALSE)
-  AnswerTests: omnitest(correctExpr = 'florence.graph <- graph.adjacency(florence, mode = "undirected", diag = FALSE)')
-  Hint: See 'Marriage Network in Renaissance Florence'. 
+- Class: cmd_question
+  Output: >
+    There are two steps to plotting the network graph of "florence".
+    First, use graph.adjacency() function to produce an "igraph" object called
+    "florence.graph". Be sure to specify that the adjancency matrix is
+    undirected and that there are no marriages within families.
+  CorrectAnswer: >-
+    florence.graph <-
+      graph.adjacency(florence, mode = "undirected", diag = FALSE)
+  AnswerTests: >-
+    omnitest(
+      correctExpr =
+        'florence.graph <- graph.adjacency(florence, mode = "undirected", diag = FALSE)'
+    )
+  Hint: See 'Marriage Network in Renaissance Florence'.
 
 - Class: cmd_question
-  Output: 'Now use the "plot()" function to visualize the marriage network described by "florence.graph".'
+  Output: >
+    Now use the "plot()" function to visualize the marriage network
+    described by "florence.graph".
   CorrectAnswer: plot(florence.graph)
   AnswerTests: omnitest(correctExpr = 'plot(florence.graph)')
-  Hint: See 'Marriage Network in Renaissance Florence'. 
+  Hint: See 'Marriage Network in Renaissance Florence'.
 
 # Question 8
 - Class: mult_question
-  Output: 'We can quantify each family''s place in the network using a measure of centrality. One common measure of centrality is known as ''betweenness''. Which of these statements best describes betweenness?'
-  AnswerChoices: 'betweenness is the proportion of shortest paths between two other nodes that contain it; A node''s betweenness is the number of nodes that are immediately connected to it; A node''s betweenness is a measure of how close it is to other nodes; None of these'
-  CorrectAnswer: betweenness is the proportion of shortest paths between two other nodes that contain it
-  AnswerTests: omnitest(correctVal = 'betweenness is the proportion of shortest paths between two other nodes that contain it')
+  Output: >
+    We can quantify each family's place in the network using a measure of
+    centrality. One common measure of centrality is known as 'betweenness'.
+    Which of these statements best describes betweenness?
+  AnswerChoices: >
+    betweenness is the proportion of shortest paths between two other nodes
+    that contain it; A node's betweenness is the number of nodes that are
+    immediately connected to it; A node's betweenness is a measure of how
+    close it is to other nodes; None of these'
+  CorrectAnswer: >
+    betweenness is the proportion of shortest paths between
+    two other nodes that contain it
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'betweenness is the proportion of shortest paths between two other nodes that contain it'
+    )
   Hint: See 'Undirected Graphs and Centrality Measures'.
 
 # Question 9
 - Class: cmd_question
-  Output: 'Compute the betweenness of each node in "florence" and store the result as an object called "between".'
+  Output: >
+    Compute the betweenness of each node in "florence"
+    and store the result as an object called "between".
   CorrectAnswer: between <- betweenness(florence.graph)
   AnswerTests: omnitest(correctExpr = 'between <- betweenness(florence.graph)')
-  Hint: See ''Undirected Graphs and Centrality Measures''. 
+  Hint: See ''Undirected Graphs and Centrality Measures''.
 
-# Question 10 
+# Question 10
 - Class: cmd_question
-  Output: 'Now, use the "sort()" function to output a vector that starts with the family with highest betweenness and ends with the family with lowest betweenness.'
+  Output: >
+    Now, use the "sort()" function to output a vector that starts
+    with the family with highest betweenness and ends with the family with
+    lowest betweenness.
   CorrectAnswer: sort(between, decreasing = TRUE)
   AnswerTests: omnitest(correctExpr = 'sort(between, decreasing = TRUE)')
-  Hint: See ''Directed Graphs and Centrality''. 
+  Hint: See ''Directed Graphs and Centrality''.
 
 - Class: text
-  Output: 'The "sort()" and "order()" functions are closely related. Whereas "sort()" returns the ordered vector itself, "order()" returns the ordering index vector.'
+  Output: >
+    The "sort()" and "order()" functions are closely related.
+    Whereas "sort()" returns the ordered vector itself,
+    "order()" returns the ordering index vector.
 
 # Question 11
 - Class: cmd_question
-  Output: 'Verify this by using "order()" and indexing to output the same vector from the previous question.'
+  Output: >
+    Verify this by using "order()" and indexing to output the same vector
+    from the previous question.
   CorrectAnswer: between[order(between, decreasing = TRUE)]
-  AnswerTests: omnitest(correctExpr = 'between[order(between, decreasing = TRUE)]')
-  Hint: See ''Directed Graphs and Centrality''. 
+  AnswerTests: >-
+    omnitest(correctExpr = 'between[order(between, decreasing = TRUE)]')
+  Hint: See ''Directed Graphs and Centrality''.
 
 # Question 12
 - Class: mult_question
-  Output: 'Based on you find, which of the elite Florentine families was most central in the marriage network?'
+  Output: >
+    Based on you find, which of the elite Florentine families was most central
+    in the marriage network?
   AnswerChoices: 'Medici; Ridolfi; Bischeri; Strozzi; Pucci'
   CorrectAnswer: Medici
   AnswerTests: omnitest(correctVal = "Medici")
-  Hint: See 'Undirected Graphs and Centrality Measures'. 
+  Hint: See 'Undirected Graphs and Centrality Measures'.
 
 - Class: text
-  Output: 'You''ve successfully completed part 2 of the Discovery course!'
+  Output: >
+    You've successfully completed part 2 of the Discovery course!
 

--- a/DISCOVERY3/lesson.yaml
+++ b/DISCOVERY3/lesson.yaml
@@ -8,7 +8,9 @@
 
 ## Conceptual Questions
 - Class: text
-  Output: 'These exercises are a companion to Chapter 5 of ''A First Course in Quantitative Social Science''.'
+  Output: >
+    These exercises are a companion to Chapter 5 of
+    'Quantitative Social Science'.
 
 # Question 1
 - Class: mult_question
@@ -17,80 +19,116 @@
   CorrectAnswer: visualize
   AnswerTests: omnitest(correctVal = 'visualize')
   Hint: See 'Spatial Data'
- 
-# Question 2 
+
+# Question 2
 - Class: mult_question
-  Output: 'John Snow used _________ to identify the cause of the cause of the 1854 cholera epidemic.'
-  AnswerChoices: 'a natural experiment; a randomized control trial; observational data'
+  Output: >
+    John Snow used _________ to identify the cause of the 1854 cholera epidemic.
+  AnswerChoices: >
+    a natural experiment; a randomized control trial; observational data
   CorrectAnswer: a natural experiment
   AnswerTests: omnitest(correctVal = 'a natural experiment')
   Hint: See 'Spatial Data'
-  
+
 # Question 3
 - Class: mult_question
-  Output: 'The hexadecimal color code is a sequence of six characters beginning with a pound sign. Each set of two digits represents the colors _______, ______, and ______.'
-  AnswerChoices: 'red, green and blue; red, yellow and blue; red, white and blue'
+  Output: >
+    The hexadecimal color code is a sequence of six characters
+    beginning with a pound sign. Each set of two digits represents the colors
+    _______, ______, and ______.
+  AnswerChoices: >
+    red, green and blue; red, yellow and blue; red, white and blue
   CorrectAnswer: red, green and blue
   AnswerTests: omnitest(correctVal = 'red, green and blue')
   Hint: See 'Colors in R'
-  
+
 # Question 4
 - Class: mult_question
-  Output: 'Look at the map of the United States 2008 presidential election results. Which feature did we use to help visualize the degree of support for Democrats and Republicans?'
+  Output: >
+    Look at the map of the United States 2008 presidential election results.
+    Which feature did we use to help visualize the degree of support for
+    Democrats and Republicans?
   AnswerChoices: 'hue; shade; transparency'
   CorrectAnswer: shade
   AnswerTests: omnitest(correctVal = 'shade')
   Hint: See 'Colors in R'
-  
+
 # Question 5
 - Class: mult_question
-  Output: 'Using color, transparency and size helps us to visualize the Walmart expansion. Which of these best describes the location of Walmart Supercenters in the U.S.?'
-  AnswerChoices: 'Supercenters equally distributed across the U.S.; Supercenters only on the coasts; Supercenters mainly in the Midwest and South'
+  Output: >
+    Using color, transparency and size helps us to visualize the
+    Walmart expansion. Which of these best describes the location of
+    Walmart Supercenters in the U.S.?
+  AnswerChoices: >
+    Supercenters equally distributed across the U.S.;
+    Supercenters only on the coasts;
+    Supercenters mainly in the Midwest and South
   CorrectAnswer: Supercenters mainly in the Midwest and South
-  AnswerTests: omnitest(correctVal = 'Supercenters mainly in the Midwest and South')
+  AnswerTests: >-
+    omnitest(correctVal = 'Supercenters mainly in the Midwest and South')
   Hint: See 'Expansion of Walmart'
 
 ## Programming Questions
 - Class: text
   Output: 'The "maps" package has been pre-loaded to assist with this lesson.'
-  
+
 # Question 6
 - Class: cmd_question
   Output: 'Use the "map()" function to draw a map of the United States.'
   CorrectAnswer: map(database = "usa")
   AnswerTests: omnitest(correctExpr = 'map(database = "usa")')
   Hint: See 'Spatial Data in R'
-  
+
 # Question 7
 - Class: text
   Output: 'From the "maps" package we have also loaded the dataset "us.cities".'
 
 - Class: cmd_question
-  Output: 'Using the "subset()" function, create an "data.frame" object called "lrgcities" which only contains cities with populations greater than 100,000. The variable for population in the "us.cities" dataset is called "pop".'
+  Output: >
+    Using the "subset()" function, create an "data.frame" object
+    called "lrgcities" which only contains cities with populations
+    greater than 100,000. The variable for population in the "us.cities" dataset
+    is called "pop".
   CorrectAnswer: lrgcities <- subset(us.cities, pop > 100000, )
-  AnswerTests: omnitest(correctExpr = 'lrgcities <- subset(us.cities, pop > 100000,)')
+  AnswerTests: >-
+    omnitest(correctExpr = 'lrgcities <- subset(us.cities, pop > 100000,)')
   Hint: See 'Spatial Data in R'
 
 # Question 8
 - Class: cmd_question
-  Output: 'Next, we want to save the USA database as a list and not a plot. Save it to an object called "usa".'
+  Output: >
+    Next, we want to save the USA database as a list and not a plot.
+    Save it to an object called "usa".
   CorrectAnswer: usa <- map(database = "usa", plot = FALSE)
-  AnswerTests: omnitest(correctExpr = 'usa <- map(database = "usa", plot = FALSE)')
+  AnswerTests: >-
+    omnitest(correctExpr = 'usa <- map(database = "usa", plot = FALSE)')
   Hint: See 'Spatial Data in R'
 
 # Question 9
 - Class: cmd_question
-  Output: 'Call the "map()" function with the database set to "state", regions to "New Jersey" and plot to "FALSE", and save the output to an object called "nj".'
-  CorrectAnswer: nj <- map(database = "state", regions = "New Jersey", plot = FALSE)
-  AnswerTests: omnitest(correctExpr = 'nj <- map(database = "state", regions = "New Jersey", plot = FALSE)')
+  Output: >
+    Call the "map()" function with the database set to "state",
+    regions to "New Jersey" and plot to "FALSE",
+    and save the output to an object called "nj".
+  CorrectAnswer: >-
+    nj <- map(database = "state", regions = "New Jersey", plot = FALSE)
+  AnswerTests: >-
+    omnitest(
+      correctExpr =
+        'nj <- map(database = "state", regions = "New Jersey", plot = FALSE)'
+    )
   Hint: See 'Spatial Data in R'
 
 # Question 10
 - Class: cmd_question
-  Output: 'Use the "rgb()" function to assign the hexadecimal code for the color blue to the object "blue".'
+  Output: >
+    Use the "rgb()" function to assign the hexadecimal code for the color blue
+    to the object "blue".
   CorrectAnswer: blue <- rgb(red = 0, green = 0, blue = 1)
-  AnswerTests: omnitest(correctExpr = 'blue <- rgb(red = 0, green = 0, blue = 1)')
+  AnswerTests: >-
+    omnitest(correctExpr = 'blue <- rgb(red = 0, green = 0, blue = 1)')
   Hint: See 'Spatial Data in R'
 
 - Class: text
-  Output: 'You''ve successfully completed part 3 of the Discovery course!'
+  Output: >
+     You've successfully completed part 3 of the Discovery course!

--- a/INTRO1/lesson.yaml
+++ b/INTRO1/lesson.yaml
@@ -7,16 +7,28 @@
   Version: 2.3.0
 
 - Class: text
-  Output: 'These exercises are a companion to Chapter 1 of ''Quantitative Social Science: Introduction''. When you see ..., press Enter.'
+  Output: >
+    These exercises are a companion to Chapter 1 of
+    'Quantitative Social Science: Introduction'.
+    When you see ..., press Enter.
 
 - Class: text
-  Output: 'If at any time you need help with R, you can type help.start() at the prompt which will open an index of R materials. Many R resources are also available on the web and are easily found through a web search.'
+  Output: >
+    If at any time you need help with R, you can type help.start()
+    at the prompt which will open an index of R materials.
+    Many R resources are also available on the web and
+    are easily found through a web search.
 
 - Class: text
-  Output: 'We will put double quotes around the names of R objects. However, in actual R code, there are only a few cases where you will need to put them in quotation marks.'
+  Output: >
+    We will put double quotes around the names of R objects.
+    However, in actual R code, there are only a few cases where
+    you will need to put them in quotation marks.
 
 - Class: text
-  Output: 'Let''s start by practicing arithmetic operations by using R as a basic calculator.'
+  Output: >
+    Let's start by practicing arithmetic operations by using R
+    as a basic calculator.
 
 # Question 1
 - Class: cmd_question
@@ -57,7 +69,7 @@
   Hint: See 'Objects'.
 
 - Class: text
-  Output: 'We can also give a name to a string of characters'
+  Output: 'We can also give a name to a string of characters.'
 
 # Question 6
 - Class: cmd_question
@@ -70,7 +82,8 @@
   Output: 'Notice that spaces are allowed in character strings.'
 
 - Class: text
-  Output: 'We can also change what a name refers to by assigning a new object to it.'
+  Output: >
+    We can also change what a name refers to by assigning a new object to it.
 
 # Question 7
 - Class: cmd_question
@@ -80,18 +93,19 @@
   Hint: See 'Objects'.'
 
 - Class: text
-  Output: 'When we assign an existing object to a new name we always make a copy of it.'
+  Output: >
+    When we assign an existing object to a new name we always make a copy of it.
 
 # Question 8
 - Class: cmd_question
-  Output: 'Assign the value of "result" to "result2"'
+  Output: 'Assign the value of "result" to "result2".'
   CorrectAnswer: 'result2 <- result'
   AnswerTests: omnitest(correctExpr='result2 <- result')
   Hint: See 'Objects'.'
 
 # Question 9
 - Class: cmd_question
-  Output: 'Now make "result" name the value of 10 minus 2'
+  Output: 'Now make "result" name the value of 10 minus 2.'
   CorrectAnswer: 'result <- 10 - 2'
   AnswerTests: omnitest(correctExpr='result <- 10 - 2')
   Hint: See 'Objects'.'
@@ -99,12 +113,18 @@
 # Question 10
 - Class: mult_question
   Output: 'What do you think R will return when we type "c(result, result2)"?'
-  AnswerChoices: 'a six and a six; an eight and a six; a six and an eight; an eight and an eight'
+  AnswerChoices: >
+    a six and a six; an eight and a six; a six and an eight;
+    an eight and an eight
   CorrectAnswer: an eight and a six
   AnswerTests: omnitest(correctVal = 'an eight and a six')
 
 - Class: text
-  Output: 'Next, we are going to start working with real data: estimates of world population (in thousands). A vector of data called "world.pop" has been loaded with this lesson. The first element is for the year 1950 up to the last element for 2010.'
+  Output: >
+    Next, we are going to start working with real data:
+    estimates of world population (in thousands).
+    A vector of data called "world.pop" has been loaded with this lesson.
+    The first element is for the year 1950 up to the last element for 2010.
 
 # Question 11
 - Class: cmd_question
@@ -122,9 +142,12 @@
 
 # Question 13
 - Class: cmd_question
-  Output: 'Use indexing and concatenation to get just the 1st and 4th elements of "world.pop"'
+  Output: >
+    Use indexing and concatenation to get just the 1st and 4th elements of
+    "world.pop".
   CorrectAnswer: 'world.pop[c(1,4)]'
-  AnswerTests: any_of_exprs('world.pop[c(1,4)]', 'c(world.pop[1], world.pop[4])')
+  AnswerTests: >-
+    any_of_exprs('world.pop[c(1,4)]', 'c(world.pop[1], world.pop[4])')
   Hint: See 'Vectors'.
 
 - Class: text
@@ -132,31 +155,44 @@
 
 # Question 14
 - Class: cmd_question
-  Output: 'How would you find the length of i.e., the number of elements in, the "world.pop" vector?'
+  Output: >
+    How would you find the length of i.e., the number of elements in,
+    the "world.pop" vector?
   CorrectAnswer: 'length(world.pop)'
   AnswerTests: omnitest(correctExpr='length(world.pop)')
   Hint: See 'Functions'.
 
 # Question 15
 - Class: cmd_question
-  Output: 'Create a vector using the sequence function that goes from 1950 to 2010 in increments of 10. Assign this vector to an object called "year".'
+  Output: >
+    Create a vector using the sequence function that goes from 1950 to 2010
+    in increments of 10. Assign this vector to an object called "year".
   CorrectAnswer: 'year <- seq(from = 1950, to = 2010, by = 10)'
-  AnswerTests: any_of_exprs('year <- seq(from = 1950, to = 2010, by = 10)', 'year <- seq(1950, 2010, 10)')
+  AnswerTests: >-
+    any_of_exprs(
+      'year <- seq(from = 1950, to = 2010, by = 10)'
+    )
   Hint: See 'Functions'.
 
 # Question 16
 - Class: cmd_question
-  Output: 'Use the "year" vector just created to give names to the elements of the "world.pop" vector.'
+  Output: >
+    Use the "year" vector just created to give names to the elements
+    of the "world.pop" vector.
   CorrectAnswer: 'names(world.pop) <- year'
-  AnswerTests: any_of_exprs('names(world.pop) <- year', 'setNames(world.pop) <- year')
+  AnswerTests: >-
+    any_of_exprs('names(world.pop) <- year', 'setNames(world.pop) <- year')
   Hint: See 'Functions'.
 
 - Class: text
-  Output: 'We have included a vector "x" in this lesson. This vector contains 10 integers from 0 to 100.'
+  Output: >
+    We have included a vector "x" in this lesson.
+    This vector contains 10 integers from 0 to 100.
 
 # Question 17
 - Class: cmd_question
-  Output: 'How would you replace the first element in "x" with a missing value?'
+  Output: >
+    How would you replace the first element in "x" with a missing value?
   CorrectAnswer: 'x[1] <- NA'
   AnswerTests: any_of_exprs('x[1] <- NA', 'x <- replace(x, 1, NA)')
   Hint: See 'Functions'.
@@ -164,11 +200,14 @@
 # Question 18
 - Class: mult_question
   Output: 'What do you think R will return when we type "mean(x)"?'
-  AnswerChoices: 'the average of the remaining numbers; the fifth highest number in "x"; a missing value'
+  AnswerChoices: >
+    the average of the remaining numbers;
+    the fifth highest number in "x"; a missing value
   CorrectAnswer: a missing value
   AnswerTests: omnitest(correctVal = 'a missing value')
   Hint: See 'Data Files'.
 
 - Class: text
-  Output: 'You''ve successfully completed part 1 of the Intro course!'
+  Output: >
+    You've successfully completed part 1 of the Intro course!
 

--- a/INTRO2/lesson.yaml
+++ b/INTRO2/lesson.yaml
@@ -76,7 +76,7 @@
 - Class: cmd_question
   Output: 'Find the maximum value in "x".'
   CorrectAnswer: 'max(x)'
-  AnswerTests: omnitest(correctExpr = 'max(x)')
+  AnswerTests: omnitest(correctExpr = any_of_exprs('max(x)', 'max(x, na.rm = TRUE)'))
   Hint: See 'Functions'.
 
 - Class: text

--- a/INTRO2/lesson.yaml
+++ b/INTRO2/lesson.yaml
@@ -7,28 +7,34 @@
   Version: 2.2.21
 
 - Class: text
-  Output: 'These exercises are a companion to Chapter 1 of ''Quantitative Social Science: Introduction''.'
+  Output: >
+    These exercises are a companion to Chapter 1 of
+    'Quantitative Social Science: Introduction'.
 
 # Question 1
 - Class: cmd_question
   Output: 'How would you multiply 4 by 7?'
   CorrectAnswer: '4 * 7'
-  AnswerTests: omnitest(correctExpr='4 * 7')
+  AnswerTests: any_of_exprs('4 * 7', '7 * 4')
   Hint: See 'Arithmetic Operations'.
 
 # Question 2
 - Class: cmd_question
   Output: 'How would you multiply 2 by the result of 9 plus 1?'
   CorrectAnswer: '2 * (9 + 1)'
-  AnswerTests: any_of_exprs('2 * (9 + 1)', '(9 + 1) * 2')
+  AnswerTests: >-
+    any_of_exprs('2 * (9 + 1)', '(9 + 1) * 2', '2 * (1 + 9)', '(1 + 9) * 2')
   Hint: See 'Arithmetic Operations'.
 
 - Class: text
-  Output: 'R will treat numbers like characters if you tell it to. However, you will no longer be able to use arithmetic operations on the object.'
+  Output: >
+    R will treat numbers like characters if you tell it to.
+    However, you will no longer be able to use arithmetic operations
+    on the object.
 
 # Question 3
 - Class: cmd_question
-  Output: 'give the value 10 the name "myobject".'
+  Output: 'Assign the value 10 to "myobject".'
   CorrectAnswer: 'myobject <- 10'
   AnswerTests: omnitest(correctExpr='myobject <- 10')
   Hint: See 'Objects'.
@@ -63,37 +69,51 @@
   Hint: See 'Objects'.
 
 - Class: text
-  Output: 'A vector called "x" with 10 integers from 1 to 100 has been included in this lesson.'
+  Output: >
+    A vector called "x" with 10 integers from 1 to 100 has
+    been included in this lesson.
 
 # Question 8
 - Class: cmd_question
   Output: 'Concatenate the first two elements of "x".'
   CorrectAnswer: 'c(x[1],x[2])'
-  AnswerTests: any_of_exprs('c(x[1],x[2])', 'x[c(1,2)]', 'x[1:2]')
+  AnswerTests: >-
+    any_of_exprs(
+      'c(x[1],x[2])', 'x[c(1,2)]', 'x[1:2]', 'x[seq(2)]', 'x[seq(1, 2)]',
+      'x[seq(1, 2, by = 1)]'
+    )
   Hint: See 'Vectors'.
 
 # Question 9
 - Class: cmd_question
   Output: 'Find the maximum value in "x".'
   CorrectAnswer: 'max(x)'
-  AnswerTests: omnitest(correctExpr = any_of_exprs('max(x)', 'max(x, na.rm = TRUE)'))
+  AnswerTests: any_of_exprs('max(x)', 'max(x, na.rm = TRUE)')
   Hint: See 'Functions'.
 
 - Class: text
-  Output: 'A vector of data called "world.pop" has been loaded with this lesson. The first element is for the year 1950 up to the last element for 2010.'
+  Output: >
+    A vector of data called "world.pop" has been loaded with this lesson.
+    The first element is for the year 1950 up to the last element for 2010.
 
 - Class: text
-  Output: '"world.pop" is a numeric vector so we can perform arithmetic operations on it.'
+  Output: >
+    "world.pop" is a numeric vector
+    so we can perform arithmetic operations on it.
 
 # Question 10
 - Class: cmd_question
-  Output: 'Divide each element of "world.pop" by 1000 and call the result "pop.million".'
+  Output: >
+    Divide each element of "world.pop" by 1000
+    and call the result "pop.million".
   CorrectAnswer: 'pop.million <- world.pop / 1000'
   AnswerTests: omnitest(correctExpr='pop.million <- world.pop / 1000')
   Hint: See 'Vectors'.
 
 - Class: text
-  Output: 'Included in this lesson is a CSV data file called "data.csv". For convenience, the file path to "data.csv" is called "data_path".'
+  Output: >
+    Included in this lesson is a CSV data file called "data.csv".
+    For convenience, the file path to "data.csv" is called "data_path".
 
 # Question 11
 - Class: cmd_question
@@ -104,13 +124,21 @@
 
 # Question 12
 - Class: cmd_question
-  Output: 'Using "data_path" as the path, read the content of the data file and call it "df".'
+  Output: >
+    Using "data_path" as the path,
+    read the content of the data file and call it "df".
   CorrectAnswer: 'df <- read.csv(data_path, header = TRUE)'
-  AnswerTests: any_of_exprs('df <- read.csv(data_path, header = TRUE)', 'df <- read.csv(data_path, header = T)', 'df <- read.csv(data_path)')
+  AnswerTests: >-
+    any_of_exprs(
+      'df <- read.csv(data_path, header = TRUE)',
+      'df <- read.csv(data_path, header = T)',
+      'df <- read.csv(data_path)'
+    )
   Hint: See 'Data Files'.
 
 - Class: text
-  Output: 'A data frame object called "UNpop" has already been included in this lesson.'
+  Output: >
+    A data frame object called "UNpop" has already been included in this lesson.
 
 # Question 13
 - Class: cmd_question
@@ -128,17 +156,38 @@
 
 # Question 15
 - Class: cmd_question
-  Output: 'Use indexing and/or the $ operator to look at the last four observations of the "year" variable from the "UNpop" data frame.'
+  Output: >
+    Use indexing and/or the $ operator to look at the last four observations
+    of the "year" variable from the "UNpop" data frame.
   CorrectAnswer: 'UNpop$year[4:7]'
-  AnswerTests: any_of_exprs('UNpop[4:7, "year"]', 'UNpop[4:7, 2]', 'UNpop$year[4:7]', 'UNpop[c(4:7), "year"]', 'UNpop[c(4:7), 2]', 'UNpop$year[c(4:7)]', 'UNpop$year[seq(from = 4, to = 7)]')
+  AnswerTests: >-
+    any_of_exprs(
+      'UNpop[4:7, "year"]', 'UNpop[4:7, 2]', 'UNpop$year[4:7]',
+      'UNpop[c(4:7), "year"]', 'UNpop[c(4:7), 2]', 'UNpop$year[c(4:7)]',
+      'UNpop$year[seq(from = 4, to = 7)]',
+      'UNpop$year[seq(from = 4, to = 7, by = 1)]',
+      'UNpop[(dim(UNpop)[1] - 3):dim(UNpop)[1], "year"]',
+      'UNpop[(dim(UNpop)[1] - 3):dim(UNpop)[1], 2]',
+      'UNpop$year[(dim(UNpop)[1] - 3):dim(UNpop)[1]]',
+      'UNpop[c((dim(UNpop)[1] - 3):dim(UNpop)[1]), "year"]',
+      'UNpop[c((dim(UNpop)[1] - 3):dim(UNpop)[1]), 2]',
+      'UNpop$year[c((dim(UNpop)[1] - 3):dim(UNpop)[1])]',
+      'UNpop$year[seq(from = dim(UNpop)[1] - 3, to = dim(UNpop)[1])]',
+      'UNpop$year[seq(from = dim(UNpop)[1] - 3, to = dim(UNpop)[1], by = 1)]'
+    )
   Hint: See 'Data Files'.
 
 - Class: text
-  Output: 'Notice that you have to quote the name of the variable if you index into "UNpop", but not if you use the dollar sign.'
+  Output: >
+    Notice that you have to quote the name of the variable
+    if you index into "UNpop", but not if you use the dollar sign.
 
 # Question 16
 - Class: cmd_question
-  Output: 'R uses a special character to denote comments. Use the "print()" function to write ''X starts every comment''. Replace X with the appropriate character.'
+  Output: >
+    R uses a special character to denote comments.
+    Use the "print()" function to write 'X starts every comment'.
+    Replace X with the appropriate character.
   CorrectAnswer: 'print("# starts every comment")'
   AnswerTests: omnitest(correctExpr='print("# starts every comment")')
   Hint: See 'Data Files'.
@@ -151,4 +200,5 @@
   Hint: See 'Data Files'.
 
 - Class: text
-  Output: 'You''ve successfully completed part 2 of the Intro course!'
+  Output: >
+    You've successfully completed part 2 of the Intro course!

--- a/MEASUREMENT1/lesson.yaml
+++ b/MEASUREMENT1/lesson.yaml
@@ -13,17 +13,25 @@
 # Question 1
 - Class: mult_question
   Output: 'What are some reasons for non-response in surveys?'
-  AnswerChoices: 'respondents refuse to answer; respondents don''t know the answer; both of these'
+  AnswerChoices: >
+    respondents refuse to answer;
+    respondents don't know the answer;
+    both of these
   CorrectAnswer: both of these
   AnswerTests: omnitest(correctVal='both of these')
   Hint: See 'Handling Missing Data in R'
 
 # Question 2
 - Class: mult_question
-  Output: 'Listwise deletion will delete an entire observation if ________.'
-  AnswerChoices: 'at least one of its variables has a missing value; if all of its variables are missing; if none of its variables are missing'
+  Output: >
+    Listwise deletion will delete an entire observation if ________.
+  AnswerChoices: >
+    at least one of its variables has a missing value;
+    if all of its variables are missing;
+    if none of its variables are missing
   CorrectAnswer: at least one of its variables has a missing value
-  AnswerTests: omnitest(correctVal='at least one of its variables has a missing value')
+  AnswerTests: >-
+    omnitest(correctVal='at least one of its variables has a missing value')
   Hint: See 'Handling Missing Data in R'
 
 # Question 3
@@ -36,8 +44,11 @@
 
 # Question 4
 - Class: mult_question
-  Output: 'When printing and saving graphs use __________ to open a pdf device and __________ to close the device.'
-  AnswerChoices: 'pdf() and dev.off(); pdf.open() and dev.close(); pdf.on() and dev()'
+  Output: >
+    When printing and saving graphs use __________ to open a pdf device and
+    __________ to close the device.
+  AnswerChoices: >
+    pdf() and dev.off(); pdf.open() and dev.close(); pdf.on() and dev()
   CorrectAnswer: pdf() and dev.off()
   AnswerTests: omnitest(correctVal='pdf() and dev.off()')
   Hint: See 'Printing and Saving Graphs'
@@ -45,7 +56,9 @@
 
 # Question 5
 - Class: mult_question
-  Output: '''Without replacement'' in a survey means each individual is interviewed __________.'
+  Output: >
+    'Without replacement' in a survey means each individual is interviewed
+    __________.
   AnswerChoices: 'once; many times; either of these'
   CorrectAnswer: once
   AnswerTests: omnitest(correctVal='once')
@@ -53,7 +66,10 @@
 
 ## Programming questions
 - Class: text
-  Output: 'We will start by using "afghan.csv" dataset described in the chapter. It has already been loaded for you and should show up in your Environment window.'
+  Output: >
+    We will start by using "afghan.csv" dataset described in the chapter.
+    It has already been loaded for you and should show up in your
+    Environment window.
 
 # Question 6
 - Class: cmd_question
@@ -64,7 +80,8 @@
 
 # Question 7
 - Class: mult_question
-  Output: 'Looking at the summary data, which of these variables has missing values?'
+  Output: >
+    Looking at the summary data, which of these variables has missing values?
   AnswerChoices: '"violent.exp.ISAF"; "employed"; "age"'
   CorrectAnswer: violent.exp.ISAF
   AnswerTests: omnitest(correctVal='"violent.exp.ISAF"')
@@ -72,27 +89,43 @@
 
 # Question 8
 - Class: cmd_question
-  Output: 'Looking at the summary statistics, what is the mean number of years of education among the respondents?'
+  Output: >
+    Looking at the summary statistics, what is the mean number of years of
+    education among the respondents?
   CorrectAnswer: '4'
   AnswerTests: any_of_exprs('4', '4.0', '4.00', '4.002','4.002179')
-  Hint: See 'Measuring Civilian Victimization during Wartime.' Interpret the summary statistics and type the number of years, don't use any functions.
+  Hint: >
+    See 'Measuring Civilian Victimization during Wartime.'
+    Interpret the summary statistics and type the number of years
+    while not using any functions.
 
 # Question 9
 - Class:  cmd_question
   Output: 'Make a table of proportions in each province by employment status.'
   CorrectAnswer: prop.table(table(afghan$province, afghan$employed))
-  AnswerTests: any_of_exprs('prop.table(table(afghan$province, afghan$employed))', 'prop.table(table(afghan$employed, afghan$province))', 'prop.table(table(province = afghan$province, employed = afghan$employed))', 'prop.table(table(employed = afghan$employed, province = afghan$province))', 'prop.table(table(Province = afghan$province, Employed = afghan$employed))', 'prop.table(table(Employed = afghan$employed, Province = afghan$province))')
+  AnswerTests: >-
+    any_of_exprs(
+    'prop.table(table(afghan$province, afghan$employed))',
+    'prop.table(table(afghan$employed, afghan$province))',
+    'prop.table(table(province = afghan$province, employed = afghan$employed))',
+    'prop.table(table(employed = afghan$employed, province = afghan$province))',
+    'prop.table(table(Province = afghan$province, Employed = afghan$employed))',
+    'prop.table(table(Employed = afghan$employed, Province = afghan$province))'
+    )
   Hint: See 'Measuring Civilian Victimization during Wartime'
 
 # Question 10
 - Class: cmd_question
-  Output: 'How would you count the total number of missing elements of "violent.exp.taliban"?'
+  Output: >
+    How would you count the total number of missing elements of
+    "violent.exp.taliban"?
   CorrectAnswer: sum(is.na(afghan$violent.exp.taliban))
   AnswerTests: omnitest(correctExpr='sum(is.na(afghan$violent.exp.taliban))')
   Hint: See 'Handling Missing Data in R'
 
 - Class: text
-  Output: 'You''ve successfully completed part 1 of the Measurement course!'
+  Output: >
+    You've successfully completed part 1 of the Measurement course!
 
 
 

--- a/MEASUREMENT2/lesson.yaml
+++ b/MEASUREMENT2/lesson.yaml
@@ -15,7 +15,9 @@
 ## Conceptual questions
 # Question 1
 - Class: mult_question
-  Output: 'In section 3.6, what kind of plot are we using to visualize ideological differences between Democrats and Republicans?'
+  Output: >
+    In section 3.6, what kind of plot are we using to visualize
+    ideological differences between Democrats and Republicans?
   AnswerChoices: 'scatterplot; bar plot; histogram'
   CorrectAnswer: scatterplot
   AnswerTests: omnitest(correctVal='scatterplot')
@@ -23,7 +25,9 @@
 
 # Question 2
 - Class: mult_question
-  Output: 'True or False: Political polarization describes the phenomenon where the ideological centers of two political parties diverge over time.'
+  Output: >
+    True or False: Political polarization describes the phenomenon where the
+    ideological centers of two political parties diverge over time.
   AnswerChoices: 'True; False'
   CorrectAnswer: 'True'
   AnswerTests: omnitest(correctVal='True')
@@ -31,7 +35,8 @@
 
 # Question 3
 - Class: mult_question
-  Output: 'What angle is the Lorenz curve if everyone earns exactly the same income?'
+  Output: >
+    What angle is the Lorenz curve if everyone earns exactly the same income?
   AnswerChoices: '30 degrees; 45 degrees; 90 degrees'
   CorrectAnswer: 45 degrees
   AnswerTests: omnitest(correctVal='45 degrees')
@@ -39,7 +44,9 @@
 
 # Question 4
 - Class: mult_question
-  Output: 'To estimate the correlation between two variables x and y, we need to know the mean of each as well as the _______________________.'
+  Output: >
+    To estimate the correlation between two variables x and y, we need to know
+    the mean of each as well as the _______________________.
   AnswerChoices: 'maximum; standard deviation; length'
   CorrectAnswer: standard deviation
   AnswerTests: omnitest(correctVal='standard deviation')
@@ -47,30 +54,50 @@
 
 # Question 5
 - Class: mult_question
-  Output: 'In the kmeans() function which option is used to define the number of clusters?'
+  Output: >
+    In the kmeans() function which option is used to define the number of
+    clusters?
   AnswerChoices: 'centers; groups; iterations'
   CorrectAnswer: centers
   AnswerTests: omnitest(correctVal='centers')
   Hint: See 'Clustering'
 
-## Programming Questions  
+## Programming Questions
 # Question 6
 - Class: cmd_question
-  Output: 'Use "matrix()" to create a matrix of 2 rows by 5 columns filled by row with the numbers 1 through 10. Assign this matrix to an object called "x".'
+  Output: >
+    Use "matrix()" to create a matrix of 2 rows by 5 columns filled by row
+    with the numbers 1 through 10. Assign this matrix to an object called "x".
   CorrectAnswer: x <- matrix(1:10, nrow = 2, ncol = 5, byrow = TRUE)
-  AnswerTests: omnitest(correctExpr='x <- matrix(1:10, nrow = 2, ncol = 5, byrow = TRUE)')
+  AnswerTests: >-
+    any_of_exprs(
+      'x <- matrix(1:10, nrow = 2, ncol = 5, byrow = TRUE)',
+      'x <- matrix(1:10, ncol = 5, byrow = TRUE)',
+      'x <- matrix(1:10, nrow = 2, byrow = TRUE)',
+      'x <- matrix(seq(10), nrow = 2, ncol = 5, byrow = TRUE)',
+      'x <- matrix(seq(10), nrow = 2, byrow = TRUE)',
+      'x <- matrix(seq(10), ncol = 5, byrow = TRUE)'
+    )
   Hint: See 'Matrix in R'
 
 # Question 7
 - Class: cmd_question
   Output: 'Take the row means of this matrix'
   CorrectAnswer: rowMeans(x)
-  AnswerTests: any_of_exprs('rowMeans(x)', 'rowSums(x) / ncol(x)', 'apply(x, 1, mean)', 'c(mean(x[1, ]), mean(x[2, ]))')
+  AnswerTests: >-
+    any_of_exprs(
+      'rowMeans(x)',
+      'rowSums(x) / ncol(x)',
+      'apply(x, 1, mean)',
+      'c(mean(x[1, ]), mean(x[2, ]))'
+    )
   Hint: See 'Matrix in R'
 
 # Question 8
 - Class: cmd_question
-  Output: 'A list, "z", has been included in this lesson. Call the list object to see what it looks like.'
+  Output: >
+    A list, "z", has been included in this lesson.
+    Call the list object to see what it looks like.
   CorrectAnswer: z
   AnswerTests: omnitest(correctExpr='z')
   Hint: See 'List in R'
@@ -81,13 +108,16 @@
   CorrectAnswer: z[[1]]
   AnswerTests: omnitest(correctExpr='z[[1]]')
   Hint: See 'List in R'
-  
+
 # Question 10
 - Class: cmd_question
-  Output: 'Call the third element of the list using brackets and the name of the third element.'
+  Output: >
+    Call the third element of the list using brackets
+    and the name of the third element.
   CorrectAnswer: z[["z3"]]
   AnswerTests: omnitest(correctExpr='z[["z3"]]')
   Hint: See 'List in R'
-  
+
 - Class: text
-  Output: 'You''ve successfully completed part 2 of the Measurement course!'
+  Output: >
+    You've successfully completed part 2 of the Measurement course!

--- a/PREDICTION1/lesson.yaml
+++ b/PREDICTION1/lesson.yaml
@@ -8,10 +8,12 @@
 
 - Class: text
   Output: 'The following exercises are a companion to Chapter 4: Prediction.'
-  
+
 # Question 1
 - Class: mult_question
-  Output: 'True or False: Loops can simplify our programming code when we want to repeatedly execute code chunks over and over again.'
+  Output: >
+    True or False: Loops can simplify our programming code
+    when we want to repeatedly execute code chunks over and over again.
   AnswerChoices: '"True"; "False"'
   CorrectAnswer: 'True'
   AnswerTests: omnitest(correctVal='"True"')
@@ -27,74 +29,134 @@
 
 # Question 3
 - Class: cmd_question
-  Output: 'Given that "n <- 10", how many times will the loop "for (i in 1:n)" iterate through?'
+  Output: >
+    Given that "n <- 10",
+    how many times will the loop "for (i in 1:n)" iterate through?
   CorrectAnswer: '10'
   AnswerTests: omnitest(correctExpr='10')
   Hint: See 'Loop in R'
 
 # Question 4
 - Class: mult_question
-  Output: 'In the conditional expression "if (Y) {expression1}", "expression1" will be executed if "Y" is _____.'
+  Output: >
+    In the conditional expression "if (Y) {expression1}",
+    "expression1" will be executed if "Y" is _____.'
   AnswerChoices: 'True; False'
   CorrectAnswer: 'True'
   AnswerTests: omnitest(correctVal='True')
-  Hint: See 'General Conditional Statements in R' 
+  Hint: See 'General Conditional Statements in R'
 
 # Question 5
 - Class: mult_question
-  Output: 'A conditional statement that is nested within a loop is executed _____ the loop.'
+  Output: >
+    A conditional statement that is nested within a loop is executed _____
+    the loop.
   AnswerChoices: 'inside; outside'
   CorrectAnswer: inside
   AnswerTests: omnitest(correctVal='inside')
-  Hint: See 'General Conditional Statements in R' 
+  Hint: See 'General Conditional Statements in R'
 
 ## Programming Questions
 - Class: text
-  Output: 'It is often useful to create an empty vector to store the computational output from a loop'
+  Output: >
+    It is often useful to create an empty vector to store
+    the computational output from a loop.
 
 # Question 6
 - Class: cmd_question
-  Output: 'Create a vector called "output" that is filled with "NA"s and has the length "n". The object "n" has been included in this lesson.'
+  Output: >
+    Create a vector called "output" that is filled with "NA"s
+    and has the length "n". The object "n" has been included in this lesson.
   CorrectAnswer: output <- rep(NA, n)
   AnswerTests: omnitest(correctExpr='output <- rep(NA,n)')
   Hint: See 'Loop in R'
 
 # Question 7
 - Class: cmd_question
-  Output: 'Use the "cat()" function to put together a phrase and the object "n". The final output should read ''The object n has value 10''.'
+  Output: >
+    Use the "cat()" function to put together a phrase and the object "n".
+    The final output should read 'The object n has value 10'.
   CorrectAnswer: cat("The object n has value", n)
   AnswerTests: omnitest(correctExpr='cat("The object n has value", n)')
   Hint: See 'Loop in R.' You shouldn't need to type any numbers.
 
 # Question 8
 - Class: cmd_question
-  Output: 'A vector called "fruit" has been loaded for you. Call the vector to see what it looks like.'
+  Output: >
+    A vector called "fruit" has been loaded for you.
+    Call the vector to see what it looks like.
   CorrectAnswer: fruit
   AnswerTests: omnitest(correctExpr='fruit')
 
 # Question 9
 - Class: cmd_question
-  Output: 'Use a function to determine the different types of fruit (we want to see each fruit listed once).' 
+  Output: >
+    Use a function to determine the different types of fruit
+    (we want to see each fruit listed once).
   CorrectAnswer: unique(fruit)
   AnswerTests: omnitest(correctExpr='unique(fruit)')
   Hint: See 'Poll Predictions'
 
 # Question 10
 - Class: cmd_question
-  Output: 'Here is a variant of the classic ''FizzBuzz'' coding question. Write a for loop that executes the code ''cat(''The following number i is divisible by 3'', i, ''\n'')'' for numbers from 1 to 50 (inclusive) only for the numbers divisible by 3. Include brackets for the conditional.'
-  CorrectAnswer: for(i in 1:50){if (i %% 3 == 0) { cat("The following number i is divisible by 3", i, "\n") }}
-  AnswerTests: omnitest(correctExpr='for(i in 1:50){if (i %% 3 == 0) { cat("The following number i is divisible by 3", i, "\n") }}')
-  Hint: See 'Loop in R' and 'General Conditional Statements in R'. The modulo operator is "%%".
+  Output: >
+    Here is a variant of the classic 'FizzBuzz' coding question.
+    Write a for loop that executes the code
+    'cat('The following number i is divisible by 3', i, '\n')'
+    for numbers from 1 to 50 (inclusive) only for the numbers divisible by 3.
+    Include brackets for the conditional.
+  CorrectAnswer: >-
+    for (i in 1:50) {
+      if (i %% 3 == 0) {
+        cat("The following number i is divisible by 3", i, "\n")
+      }
+    }
+  AnswerTests: >-
+    omnitest(
+      correctExpr =
+        'for (i in 1:50) {
+           if (i %% 3 == 0) {
+             cat("The following number i is divisible by 3", i, "\n")
+           }
+         }'
+    )
+  Hint: >
+    See 'Loop in R' and 'General Conditional Statements in R'.
+    The modulo operator is "%%".
 
 # Question 11
 - Class: cmd_question
-  Output: 'Continuing from the previous FizzBuzz code you wrote, if the number is divisible by 5 (but not by 3), execute the code ''cat(''The following number i is divisible by 5'', i, ''\n'')''.'
-  CorrectAnswer: for(i in 1:50){if (i %% 3 == 0) { cat("The following number i is divisible by 3", i, "\n") } else if (i %% 5 == 0) { cat("The following number i is divisible by 5", i, "\n")}}
-  AnswerTests: omnitest(correctExpr='for(i in 1:50){if (i %% 3 == 0) { cat("The following number i is divisible by 3", i, "\n") } else if (i %% 5 == 0) { cat("The following number i is divisible by 5", i, "\n")}}')
+  Output: >
+    Continuing from the previous FizzBuzz code you wrote,
+    if the number is divisible by 5 (but not by 3), execute the code
+    'cat('The following number i is divisible by 5', i, '\n')'.
+  CorrectAnswer: >-
+    for (i in 1:50) {
+      if (i %% 3 == 0) {
+        cat("The following number i is divisible by 3", i, "\n")
+      } else if (i %% 5 == 0) {
+        cat("The following number i is divisible by 5", i, "\n")
+      }
+    }
+  AnswerTests: >-
+    any_of_exprs(
+      'for (i in 1:50) {
+         if (i %% 3 == 0) {
+           cat("The following number i is divisible by 3", i, "\n")
+         } else if (i %% 5 == 0) {
+           cat("The following number i is divisible by 5", i, "\n")
+         }
+       }',
+      'for (i in seq(50)) {
+         if (i %% 3 == 0) {
+           cat("The following number i is divisible by 3", i, "\n")
+         } else if (i %% 5 == 0) {
+           cat("The following number i is divisible by 5", i, "\n")
+         }
+       }'
+    )
   Hint: The answer involves adding a single else if condition.
 
 - Class: text
-  Output: 'You''ve successfully completed part 1 of the Prediction course!'
-
-
-
+  Output: >
+    You've successfully completed part 1 of the Prediction course!

--- a/PREDICTION2/lesson.yaml
+++ b/PREDICTION2/lesson.yaml
@@ -8,10 +8,12 @@
 
 - Class: text
   Output: 'The following exercises are a companion to Chapter 4: Prediction.'
-  
-# Question 1  
+
+# Question 1
 - Class: mult_question
-  Output: 'True or False: A positive correlation means that one variable is more likely to be above its mean when the other variable is also above its mean.'
+  Output: >
+    True or False: A positive correlation means that one variable is more likely
+    to be above its mean when the other variable is also above its mean.
   AnswerChoices: 'True; False'
   CorrectAnswer: 'True'
   AnswerTests: omnitest(correctVal='True')
@@ -19,14 +21,18 @@
 
 # Question 2
 - Class: cmd_question
-  Output: 'The intercept a in the model y = a + bx + e represents the average value of y when x is equal to _____.'
+  Output: >
+    The intercept a in the model y = a + bx + e represents
+    the average value of y when x is equal to _____.
   CorrectAnswer: '0'
   AnswerTests: omnitest(correctExpr='0')
   Hint: See 'Least squares'
 
 # Question 3
 - Class: mult_question
-  Output: 'We use the regression line to predict the value of the outcome variable y hat, otherwise known as _____'
+  Output: >
+    We use the regression line to predict the value of the outcome variable
+    y hat, otherwise known as _____.
   AnswerChoices: 'predicted value; fitted value; both of these'
   CorrectAnswer: both of these
   AnswerTests: omnitest(correctVal='both of these')
@@ -42,7 +48,9 @@
 
 # Question 5
 - Class: mult_question
-  Output: 'The difference between the observed outcome and its predicted value is called a _______.'
+  Output: >
+    The difference between the observed outcome and its predicted value is
+    called a _______.
   AnswerChoices: 'residual; prediction error; either of these'
   CorrectAnswer: either of these
   AnswerTests: omnitest(correctVal='either of these')
@@ -58,7 +66,9 @@
 
 # Question 7
 - Class: cmd_question
-  Output: 'We have included two vectors x and y. Regress y on x and assign it to an object called "fit".'
+  Output: >
+    We have included two vectors x and y.
+    Regress y on x and assign it to an object called "fit".
   CorrectAnswer: fit <- lm(y ~ x)
   AnswerTests: omnitest(correctExpr='fit <- lm(y ~ x)')
   Hint: See 'Least Squares'
@@ -74,18 +84,28 @@
 - Class: cmd_question
   Output: 'How do you see the estimated coefficients from the "fit" object?'
   CorrectAnswer: coef(fit)
-  AnswerTests: any_of_exprs('coef(fit)', 'fit$coef', 'fit$coefficients')
+  AnswerTests: >-
+    any_of_exprs(
+      'coef(fit)',
+      'coefficients(fit)',
+      'fit$coef',
+      'fit$coefficients'
+    )
   Hint: See 'Least Squares'
 
 # Question 10
 - Class: cmd_question
   Output: 'What are the predicted values?'
   CorrectAnswer: fitted(fit)
-  AnswerTests: any_of_exprs('fitted(fit)', 'predict(fit)')
+  AnswerTests: >-
+    any_of_exprs(
+      'fitted(fit)',
+      'fit$fitted.values',
+      'predict(fit)'
+    )
   Hint: See 'Least Squares'
 
 - Class: text
-  Output: 'You''ve successfully completed part 2 of the Prediction course!'
-
-
+  Output: >
+    You've successfully completed part 2 of the Prediction course!
 

--- a/PREDICTION3/lesson.yaml
+++ b/PREDICTION3/lesson.yaml
@@ -10,10 +10,13 @@
   Output: 'The following exercises are a companion to Chapter 4: Prediction.'
 
 ## Conceptual Questions
-# Question 1  
+# Question 1
 - Class: mult_question
   Output: 'How can regression models be used to draw causal inference?'
-  AnswerChoices: 'by predicting counterfactual outcomes; by randomizing outcomes; by fitting a line'
+  AnswerChoices: >
+    by predicting counterfactual outcomes;
+    by randomizing outcomes;
+    by fitting a line
   CorrectAnswer: by predicting counterfactual outcomes
   AnswerTests: omnitest(correctVal='by predicting counterfactual outcomes')
   Hint: See 'Regression and Causation'
@@ -28,7 +31,9 @@
 
 # Question 3
 - Class: mult_question
-  Output: 'The main reason it is difficult to draw causal inference in observational studies is due to __________.'
+  Output: >
+    The main reason it is difficult to draw causal inference in
+    observational studies is due to __________.
   AnswerChoices: 'confounders; associations; errors'
   CorrectAnswer: confounders
   AnswerTests: omnitest(correctVal='confounders')
@@ -36,7 +41,9 @@
 
 # Question 4
 - Class: mult_question
-  Output: 'A regression discontinuity design attempts to make causal inferences by analyzing observations lying __________ a given threshold.'
+  Output: >
+    A regression discontinuity design attempts to make causal inferences by
+    analyzing observations lying __________ a given threshold.
   AnswerChoices: 'closely across; far away from'
   CorrectAnswer: closely across
   AnswerTests: omnitest(correctVal='closely across')
@@ -44,54 +51,120 @@
 
 # Question 5
 - Class: mult_question
-  Output: 'Even if the average treatment effect is positive, the same treatment may not affect everyone in the positive direction. This is an example of _________.'
-  AnswerChoices: 'heterogenous treatment effects; homogenous treatment effects; both of these'
+  Output: >
+    Even if the average treatment effect is positive,
+    the same treatment may not affect everyone in the positive direction.
+    This is an example of _________.
+  AnswerChoices: >
+    heterogenous treatment effects; homogenous treatment effects; both of these
   CorrectAnswer: heterogenous treatment effects
   AnswerTests: omnitest(correctVal='heterogenous treatment effects')
   Hint: See 'Heterogenous treatment effects'
 
 ## Programming Questions
 - Class: cmd_question
-  Output: 'A dataset called "df" has been pre-loaded for you. It contains three variables x1, x2 and y. Regress y on x1 and x2.'
+  Output: >
+    A dataset called "df" has been pre-loaded for you.
+    It contains three variables x1, x2 and y. Regress y on x1 and x2.
   CorrectAnswer: lm(y ~ x1 + x2, data = df)
-  AnswerTests: any_of_exprs('lm(y ~ x1 + x2, data = df)', 'lm(df$y ~ df$x1 + df$x2, data = df)', 'lm(df$y ~ df$x1 + df$x2)')
+  AnswerTests: >-
+    any_of_exprs(
+      'lm(y ~ x1 + x2, data = df)',
+      'lm(df$y ~ df$x1 + df$x2, data = df)',
+      'lm(df$y ~ df$x1 + df$x2)'
+    )
   Hint: See 'Regression with Multiple Predictors'
 
 # Question 6
 - Class: cmd_question
-  Output: 'Regress y on x1 and x2 again, this time omitting the intercept and saving it to the object "fit".'
+  Output: >
+    Regress y on x1 and x2 again, this time omitting the intercept
+    and saving it to the object "fit".
   CorrectAnswer: fit <- lm(y ~ -1 + x1 + x2, data = df)
-  AnswerTests: any_of_exprs('fit <- lm(y ~ -1 + x1 + x2, data = df)','fit <- lm(df$y ~ -1 + df$x1 + df$x2, data = df)', 'fit <- lm(df$y ~ -1 + df$x1 + df$x2)')
+  AnswerTests: >-
+    any_of_exprs(
+      'fit <- lm(y ~ -1 + x1 + x2, data = df)',
+      'fit <- lm(df$y ~ -1 + df$x1 + df$x2, data = df)',
+      'fit <- lm(df$y ~ -1 + df$x1 + df$x2)'
+    )
   Hint: See 'Regression with Multiple Predictors'
 
 # Question 7
 - Class: cmd_question
   Output: 'Use an R function to call the coefficients of "fit".'
   CorrectAnswer: coef(fit)
-  AnswerTests: any_of_exprs('coef(fit)', 'fit$coef', 'fit$coefficients')
+  AnswerTests: >-
+    any_of_exprs(
+      'coef(fit)',
+      'fit$coef',
+      'fit$coefficients',
+      'coefficients(fit)'
+    )
   Hint: See 'Regression with Multiple Predictors'
 
 # Question 8
 - Class: cmd_question
   Output: 'Calculate the difference in coefficients between x2 and x1 from fit.'
   CorrectAnswer: coef(fit)["x2"] - coef(fit)["x1"]
-  AnswerTests: any_of_exprs('coef(fit)["x2"] - coef(fit)["x1"]', 'coef(fit)[2] - coef(fit)[1]', 'fit$coef[2] - fit$coef[1]', 'fit$coef["x2"] - fit$coef["x1"]', 'coef(fit)["x1"] - coef(fit)["x2"]','coef(fit)[1] - coef(fit)[2]', 'fit$coef[1] - fit$coef[2]', 'fit$coef["x1"] - fit$coef["x2"]', 'fit$coefficients["x2"] - fit$coefficients["x1"]', 'fit$coefficients["x1"] - fit$coefficients["x2"]', 'fit$coefficients[2] - fit$coefficients[1]', 'fit$coefficients[1] - fit$coefficients[2]')
+  AnswerTests: >-
+    any_of_exprs(
+      'coef(fit)["x2"] - coef(fit)["x1"]',
+      'coef(fit)["x1"] - coef(fit)["x2"]',
+      'coef(fit)[2] - coef(fit)[1]',
+      'coef(fit)[1] - coef(fit)[2]',
+      'coefficients(fit)["x2"] - coefficients(fit)["x1"]',
+      'coefficients(fit)["x1"] - coefficients(fit)["x2"]',
+      'coefficients(fit)[2] - coefficients(fit)[1]',
+      'coefficients(fit)[1] - coefficients(fit)[2]',
+      'fit$coef["x2"] - fit$coef["x1"]',
+      'fit$coef["x1"] - fit$coef["x2"]',
+      'fit$coef[2] - fit$coef[1]',
+      'fit$coef[1] - fit$coef[2]',
+      'fit$coefficients["x2"] - fit$coefficients["x1"]',
+      'fit$coefficients["x1"] - fit$coefficients["x2"]',
+      'fit$coefficients[2] - fit$coefficients[1]',
+      'fit$coefficients[1] - fit$coefficients[2]'
+    )
   Hint: See 'Regression with Multiple Predictors'
 
 # Question 9
 - Class: cmd_question
-  Output: 'Run the regression again this time including x1 squared as regressor. You should also include an intercept and x1 and x2. Save it to an object called "fit2". Make sure to use the I() function when squaring the x1 term.'
+  Output: >
+    Run the regression again this time including x1 squared as regressor.
+    You should also include an intercept and x1 and x2.
+    Save it to an object called "fit2".
+    Make sure to use the I() function when squaring the x1 term.
   CorrectAnswer: fit2 <- lm(y ~ x1 + I(x1^2) + x2, data = df)
-  AnswerTests: any_of_exprs('fit2 <- lm(y ~ x1 + I(x1^2) + x2, data = df)', 'fit2 <- lm(y ~ x1 + x2 + I(x1^2), data = df)', 'fit2 <- lm(y ~ I(x1^2) + x1 + x2, data = df)', 'fit2 <- lm(y ~ I(x1^2) + x2 + x1, data = df)', 'fit2 <- lm(df$y ~ df$x1 + I(df$x1^2) + df$x2)')
+  AnswerTests: >-
+    any_of_exprs(
+      'fit2 <- lm(y ~ x1 + I(x1^2) + x2, data = df)',
+      'fit2 <- lm(y ~ x2 + I(x1^2) + x1, data = df)',
+      'fit2 <- lm(y ~ x1 + x2 + I(x1^2), data = df)',
+      'fit2 <- lm(y ~ x2 + x1 + I(x1^2), data = df)',
+      'fit2 <- lm(y ~ I(x1^2) + x1 + x2, data = df)',
+      'fit2 <- lm(y ~ I(x1^2) + x2 + x1, data = df)',
+      'fit2 <- lm(df$y ~ df$x1 + I(df$x1^2) + df$x2)',
+      'fit2 <- lm(df$y ~ df$x1 + df$x2 + I(df$x1^2))',
+      'fit2 <- lm(df$y ~ df$x2 + I(df$x1^2) + df$x1)',
+      'fit2 <- lm(df$y ~ df$x2 + df$x1 + I(df$x1^2))',
+      'fit2 <- lm(df$y ~ I(df$x1^2) + df$x2 + df$x1)',
+      'fit2 <- lm(df$y ~ I(df$x1^2) + df$x1 + df$x2)'
+    )
   Hint: See 'Regression with Multiple Predictors'
 
 # Question 10
 - Class: cmd_question
   Output: 'Use a function to predict the fitted values of "fit2".'
   CorrectAnswer: predict(fit2)
-  AnswerTests: any_of_exprs('predict(fit2)', 'fitted(fit2)')
+  AnswerTests: >-
+    any_of_exprs(
+      'predict(fit2)',
+      'fitted(fit2)',
+      'fit2$fitted.values'
+    )
   Hint: See 'Regression with Multiple Predictors'
 
 - Class: text
-  Output: 'You''ve successfully completed part 3 of the Prediction course!'
+  Output: >
+    You've successfully completed part 3 of the Prediction course!
 

--- a/PROBABILITY1/lesson.yaml
+++ b/PROBABILITY1/lesson.yaml
@@ -8,7 +8,11 @@
 
 # Question 1
 - Class: mult_question
-  Output: 'I roll a fair 6-sided die 3,000,000 times. The number 1 turns up approximately 500,000 times, so I conclude that the probability of a 1 is 1/6. This is the ___ approach to probability.'
+  Output: >
+    I roll a fair 6-sided die 3,000,000 times.
+    The number 1 turns up approximately 500,000 times,
+    so I conclude that the probability of a 1 is 1/6.
+    This is the ___ approach to probability.
   AnswerChoices: '"Frequentist"; "Bayesian"'
   CorrectAnswer: 'Frequentist'
   AnswerTests: omnitest(correctVal='"Frequentist"')
@@ -16,14 +20,21 @@
 
 # Question 2
 - Class: cmd_question
-  Output: 'Suppose that P(A)=0.4 and P(B)=0.3. What is the minimum value of P(A and not B)?'
+  Output: >
+    Suppose that P(A)=0.4 and P(B)=0.3.
+    What is the minimum value of P(A and not B)?
   CorrectAnswer: '0.1'
-  AnswerTests: omnitest(correctExpr='0.1')
-  Hint: See the Law of Total Probability. What happens if B is entirely contained in A?
+  AnswerTests: omnitest(correctExpr = '0.1', correctVal = 0.1)
+  Hint: >
+    See the Law of Total Probability.
+    What happens if B is entirely contained in A?
 
 # Question 3
 - Class: mult_question
-  Output: 'Out of all possible anagrams for the word CHAIR (including the original word), what is the probability that the letter I comes first?'
+  Output: >
+    Out of all possible anagrams for the word CHAIR
+    (including the original word),
+    what is the probability that the letter I comes first?
   AnswerChoices: '0.1; 0.2; 0.3; 0.4'
   CorrectAnswer: '0.2'
   AnswerTests: omnitest(correctVal='0.2')
@@ -31,59 +42,118 @@
 
 # Question 4
 - Class: mult_question
-  Output: 'Which of these is NOT the numerator of a correct use of Bayes Rule and/or the definition of conditional probability, for P(A | B, C)?'
-  AnswerChoices: 'P(B | A, C) P(A | C); P(B, C | A) P(A); P(A, B, C); P(A, B | C) P(C)'
+  Output: >
+    Which of these is NOT the numerator of a correct use of Bayes Rule
+    and/or the definition of conditional probability, for P(A | B, C)?
+  AnswerChoices: >
+    P(B | A, C) P(A | C); P(B, C | A) P(A); P(A, B, C); P(A, B | C) P(C)
   CorrectAnswer: 'P(A, B | C) P(C)'
   AnswerTests: omnitest(correctVal='P(A, B | C) P(C)')
   Hint: See 6.2.3.
 
 # Question 5
 - Class: cmd_question
-  Output: 'A disease affects 1% of the population. The only test for the disease returns positive 99% of the time the disease is actually there, though it returns positive 20% of the time if the disease is not actually there. You take this test and it returns positive. What is the probability you have the disease (rounded to nearest 0.01)?'
+  Output: >
+    A disease affects 1% of the population.
+    The only test for the disease returns positive 99% of the time
+    the disease is actually there, though it returns positive 20% of the time
+    if the disease is not actually there.
+    You take this test and it returns positive.
+    What is the probability you have the disease (rounded to nearest 0.01)?
   CorrectAnswer: '0.05'
-  AnswerTests: omnitest(correctExpr='0.05')
+  AnswerTests: omnitest(correctExpr = '0.05', correctVal = 0.05)
   Hint: See Section 6.2 on Conditional Probability.
 
 # Question 6
 - Class: mult_question
-  Output: 'What was the conditional independence assumption we made in our race + surname example?'
-  AnswerChoices: 'Once we know the race of the individual, we can assume that the predictor variables are independent.; Once we know the probabilities of the predictor variables we can assume that the race of the individual is independent.; Once we know the probability of the race we can assume the probabilities of the predictor variables are independent.'
-  CorrectAnswer: 'Once we know the race of the individual, we can assume that the predictor variables are independent.'
-  AnswerTests: omnitest(correctVal='Once we know the race of the individual, we can assume that the predictor variables are independent.')
+  Output: >
+    What was the conditional independence assumption we made in our
+    race + surname example?
+  AnswerChoices: >
+    Once we know the race of the individual,
+    we can assume that the predictor variables are independent.;
+    Once we know the probabilities of the predictor variables
+    we can assume that the race of the individual is independent.;
+    Once we know the probability of the race
+    we can assume the probabilities of the predictor variables are independent.
+  CorrectAnswer: >
+    Once we know the race of the individual,
+    we can assume that the predictor variables are independent.
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'Once we know the race of the individual, we can assume that the predictor variables are independent.'
+    )
   Hint: See 6.3.2.
 
 # Question 7
 - Class: cmd_question
-  Output: 'Let A and B be two independent variables that take on only the values 0 and 1. If P(A=1, B=1)=0.12, P(A=0, B=1)=0.28, and P(A=1)=0.3, what is P(A=0, B=0)?'
+  Output: >
+    Let A and B be two independent variables that take on only
+    the values 0 and 1. If P(A=1, B=1)=0.12, P(A=0, B=1)=0.28,
+    and P(A=1)=0.3, what is P(A=0, B=0)?
   CorrectAnswer: '0.42'
-  AnswerTests: omnitest(correctExpr='0.42')
+  AnswerTests: omnitest(correctExpr = '0.42', correctVal = 0.42)
   Hint: See 6.2.2.
 
 # Question 8
 - Class: mult_question
-  Output: 'There are three prisoners: A, B, & C. One prisoner, selected uniformly at random, will be pardoned while the other two will be executed. Prisoner A asks the jailer (who knows) to tell him one of the prisoners who will be executed: "If I will be pardoned, just flip a coin and tell me B or C; if C will be pardoned, tell me B; and if B will be pardoned, tell me C." The jailer says B will be executed. Using Bayes Rule, what is the numerator of the expression evaluating the probability that C is pardoned?'
-  AnswerChoices: 'P(jailer says B executed | C is pardoned) * P(C is pardoned); P(B is executed | C is pardoned) * P(B is executed); P(C is pardoned | jailer says B is executed) * P(B is executed)'
-  CorrectAnswer: 'P(jailer says B executed | C is pardoned) * P(C is pardoned)'
-  AnswerTests: omnitest(correctVal='P(jailer says B executed | C is pardoned) * P(C is pardoned)')
+  Output: >
+    There are three prisoners: A, B, & C. One prisoner, selected uniformly at
+    random, will be pardoned while the other two will be executed. Prisoner A
+    asks the jailer (who knows) to tell him one of the prisoners who will be
+    executed: "If I will be pardoned, just flip a coin and tell me B or C; if C
+    will be pardoned, tell me B; and if B will be pardoned, tell me C." The
+    jailer says B will be executed. Using Bayes Rule, what is the numerator of
+    the expression evaluating the probability that C is pardoned?
+  AnswerChoices: >
+    P(jailer says B executed | C is pardoned) * P(C is pardoned);
+    P(B is executed | C is pardoned) * P(B is executed);
+    P(C is pardoned | jailer says B is executed) * P(B is executed)
+  CorrectAnswer: >
+    P(jailer says B executed | C is pardoned) * P(C is pardoned)
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'P(jailer says B executed | C is pardoned) * P(C is pardoned)'
+    )
   Hint: See 6.2.2.
 
 # Question 9
 - Class: cmd_question
-  Output: 'Based on the previous question, What is the probability of C being pardoned (express to the nearest 0.01)?'
+  Output: >
+    Based on the previous question,
+    what is the probability of C being pardoned (express to the nearest 0.01)?
   CorrectAnswer: '0.67'
-  AnswerTests: omnitest(correctExpr='0.67')
+  AnswerTests: omnitest(correctExpr = '0.67', correctVal = 0.67)
   Hint: See 6.2.2.
 
 # Question 10
 - Class: cmd_question
-  Output: 'You have a bucket with 2 coins: one is a regular coin, while the other has heads on both sides. You pick a coin at random and flip it: it turns up heads. What is the probability you chose the fair coin (express to the nearest 0.01)?'
+  Output: >
+    You have a bucket with 2 coins:
+    one is a regular coin, while the other has heads on both sides.
+    You pick a coin at random and flip it: it turns up heads.
+    What is the probability you chose the fair coin
+    (express to the nearest 0.01)?
   CorrectAnswer: '0.33'
-  AnswerTests: omnitest(correctExpr='0.33')
+  AnswerTests: omnitest(correctExpr = '0.33', correctVal = 0.33)
   Hint: See 6.2.2.
 
 # Question 11
 - Class: cmd_question
-  Output: 'Suppose again, you have that bucket with 2 coins, one a regular coin and the other w/heads on both sides. You pick a coin at random. If at any point you get a tails, you obviously picked the fair coin. If you keep getting heads, you stop & decide it is the unfair coin, but only if the probability you picked the fair coin is less than 1/1000, otherwise you keep flipping. What is the minimum number of times you must flip heads in a row before you can decide it is indeed the unfair coin?'
+  Output: >
+    Suppose again, you have that bucket with 2 coins, one a regular coin and the
+    other w/heads on both sides. You pick a coin at random. If at any point you
+    get a tail, you obviously picked the fair coin. If you keep getting heads,
+    you stop & decide it is the unfair coin, but only if the probability you
+    picked the fair coin is less than 1/1000, and otherwise you keep flipping.
+    What is the minimum number of times you must flip heads in a row before you
+    can decide it is indeed the unfair coin?'
   CorrectAnswer: '10'
-  AnswerTests: omnitest(correctExpr='10')
+  AnswerTests: omnitest(correctExpr = '10', correctVal = 10)
   Hint: See 6.2.2.
+
+- Class: text
+  Output: >
+    You've successfully completed part 1 of the Probability course!

--- a/PROBABILITY2/lesson.yaml
+++ b/PROBABILITY2/lesson.yaml
@@ -8,14 +8,18 @@
 
 # Question 1
 - Class: cmd_question
-  Output: 'What is the probability that a random variable with a uniform distribution in the range [1, 4] takes on a value less than or equal to 2.5?'
+  Output: >
+    What is the probability that a random variable with a uniform distribution
+    in the range [1, 4] takes on a value less than or equal to 2.5?
   CorrectAnswer: '0.5'
-  AnswerTests: omnitest(correctExpr='0.5')
+  AnswerTests: omnitest(correctExpr = '0.5', correctVal = 0.5)
   Hint: See 6.4.1
 
 # Question 2
 - Class: mult_question
-  Output: 'Suppose I give you a random variable X, such that its mean is 0 and that the expectation of X^2 is 5. What is the variance of X?'
+  Output: >
+    Suppose I give you a random variable X, such that its mean is 0 and that
+    the expectation of X^2 is 5. What is the variance of X?
   AnswerChoices: '2; 3; 4; 5'
   CorrectAnswer: '5'
   AnswerTests: omnitest(correctVal='5')
@@ -23,7 +27,11 @@
 
 # Question 3
 - Class: mult_question
-  Output: 'Suppose there are 10 voters in an election for two candidates A and B. Each voter independently chooses to vote for A with probability 0.1, and for B with probability 0.9. What is the approximate probability that A gets at least 1 vote?'
+  Output: >
+    Suppose there are 10 voters in an election for two candidates A and B.
+    Each voter independently chooses to vote for A with probability 0.1,
+    and for B with probability 0.9. What is the approximate probability that
+    A gets at least 1 vote?
   AnswerChoices: '0.65; 0.5; 0.75; 0.25'
   CorrectAnswer: '0.65'
   AnswerTests: omnitest(correctVal='0.65')
@@ -31,7 +39,9 @@
 
 # Question 4
 - Class: mult_question
-  Output: 'Roughly what percentage of data with a standard normal distribution falls within +/- one standard deviation from the mean?'
+  Output: >
+    Roughly what percentage of data with a standard normal distribution falls
+    within +/- one standard deviation from the mean?
   AnswerChoices: '33; 50; 66; 87'
   CorrectAnswer: '66'
   AnswerTests: omnitest(correctVal='66')
@@ -39,14 +49,19 @@
 
 # Question 5
 - Class: cmd_question
-  Output: 'Suppose the standard deviation of a given population is 10. What is the standard deviation of sample mean within a sample of size 25 from that population?'
+  Output: >
+    Suppose the standard deviation of a given population is 10.
+    What is the standard deviation of sample mean within a sample of size 25
+    from that population?
   CorrectAnswer: '2'
-  AnswerTests: omnitest(correctExpr='2')
+  AnswerTests: omnitest(correctExpr = '2', correctVal = 2)
   Hint: See 6.5.2. What does the CLT say about the variance of a sample?
 
 # Question 6
 - Class: mult_question
-  Output: 'You have an unfair coin that shows heads with probability p=0.7. What is the probability you get your 3rd head on flip #5?'
+  Output: >
+    You have an unfair coin that shows heads with probability p=0.7.
+    What is the probability you get your 3rd head on flip #5?
   AnswerChoices: '0.19; 0.20; 0.21; 0.22'
   CorrectAnswer: '0.19'
   AnswerTests: omnitest(correctVal='0.19')
@@ -54,10 +69,15 @@
 
 # Question 7
 - Class: cmd_question
-  Output: 'Now suppose you flip a fair coin 10 times. What is the probability you get the 2nd head on flip #4 and the 5th head on flip #10 (rounded to the nearest 0.01)?'
+  Output: >
+    Now suppose you flip a fair coin 10 times.
+    What is the probability you get the 2nd head on flip #4
+    and the 5th head on flip #10 (rounded to the nearest 0.01)?
   CorrectAnswer: '0.03'
-  AnswerTests: omnitest(correctExpr='0.03')
-  Hint: What does this imply about flips 1-3 and flips 5-9? Can you use the fact that those different groups of flips are independent?
+  AnswerTests: omnitest(correctExpr = '0.03', correctVal = 0.03)
+  Hint: >
+    What does this imply about flips 1-3 and flips 5-9?
+    Can you use the fact that those different groups of flips are independent?
 
 # Question 8
 - Class: mult_question
@@ -69,7 +89,13 @@
 
 # Question 9
 - Class: cmd_question
-  Output: 'What is the (constant) slope of the CDF for a random variable X distributed uniformly from a=0 to b=20 (express to the nearest 0.01)?'
+  Output: >
+    What is the (constant) slope of the CDF for a random variable X
+    distributed uniformly from a=0 to b=20 (express to the nearest 0.01)?
   CorrectAnswer: '0.05'
-  AnswerTests: omnitest(correctExpr='0.05')
+  AnswerTests: omnitest(correctExpr = '0.05', correctVal = 0.05)
   Hint: See 6.4.1. Isn't the slope of the CDF just a fancy name for ...?
+
+- Class: text
+  Output: >
+    You've successfully completed part 2 of the Probability course!

--- a/UNCERTAINTY1/lesson.yaml
+++ b/UNCERTAINTY1/lesson.yaml
@@ -8,15 +8,27 @@
 
 # Question 1
 - Class: mult_question
-  Output: 'Which statement best describes how complete randomization differs from simple randomization?'
-  AnswerChoices: 'Only part of our sample is randomly chosen; We randomize part of the sample but do not randomize the treatment; We choose how much of the sample receives treatment a priori; We randomize the sample, a priori'
+  Output: >
+    Which statement best describes how complete randomization differs
+    from simple randomization?
+  AnswerChoices: >
+    Only part of our sample is randomly chosen;
+    We randomize part of the sample but do not randomize the treatment;
+    We choose how much of the sample receives treatment a priori;
+    We randomize the sample, a priori
   CorrectAnswer: 'We choose how much of the sample receives treatment a priori'
-  AnswerTests: omnitest(correctVal='We choose how much of the sample receives treatment a priori')
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'We choose how much of the sample receives treatment a priori'
+    )
   Hint: See 7.1.1.
 
 # Question 2
 - Class: mult_question
-  Output: 'Let variance and bias be denoted by V(x) and B(x) respectively. Then Mean Squared Error (MSE) equals:'
+  Output: >
+    Let variance and bias be denoted by V(x) and B(x) respectively.
+    Then Mean Squared Error (MSE) equals:
   AnswerChoices: 'V(x^2) + B(x); V(x) + B(x^2); V(x)^2 + B(x); V(x) + B(x)^2'
   CorrectAnswer: 'V(x) + B(x)^2'
   AnswerTests: omnitest(correctVal='V(x) + B(x)^2')
@@ -24,7 +36,10 @@
 
 # Question 3
 - Class: cmd_question
-  Output: 'The variance in a population is 5. For a sample of size 10 from that population, what is the variance in the sample mean (express your answer to the nearest 0.1)?'
+  Output: >
+    The variance in a population is 5.
+    For a sample of size 10 from that population, what is the variance in the
+    sample mean (express your answer to the nearest 0.1)?
   CorrectAnswer: '0.5'
   AnswerTests: omnitest(correctExpr='0.5')
   Hint: See 7.1.2. Use the Central Limit Theorem.
@@ -32,57 +47,107 @@
 # Question 4
 - Class: mult_question
   Output: 'In the context of confidence intervals, what is alpha?'
-  AnswerChoices: 'The probability that over repeated sampling the confidence interval does not contain the true value of a parameter; The probability that the confidence interval contains the true value of a parameter, based on sample size; The probability that the confidence interval contains the true value of a parameter, regardless of sample size; The bias in the probability that the confidence interval contains the true value of a parameter'
-  CorrectAnswer: 'The probability that over repeated sampling the confidence interval does not contain the true value of a parameter'
-  AnswerTests: omnitest(correctVal='The probability that over repeated sampling the confidence interval does not contain the true value of a parameter')
+  AnswerChoices: >
+    The probability that over repeated sampling the confidence interval does not
+    contain the true value of a parameter;
+    The probability that the confidence interval contains the true value of a
+    parameter, based on sample size;
+    The probability that the confidence interval contains the true value of a
+    parameter, regardless of sample size;
+    The bias in the probability that the confidence interval contains the true
+    value of a parameter'
+  CorrectAnswer: >
+    The probability that over repeated sampling the confidence interval does not
+    contain the true value of a parameter
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'The probability that over repeated sampling the confidence interval does not contain the true value of a parameter'
+    )
   Hint: See 7.1.2.
 
 # Question 5
 - Class: cmd_question
-  Output: 'In our sample of voters we find that 70% of the participants support Obama. If we want our 95% confidence interval for the true population proportion to be within +/- 1% of the true value, what is the minimum number of participants we must ask?'
+  Output: >
+    In our sample of voters we find that 70% of the participants support Obama.
+    If we want our 95% confidence interval for the true population proportion
+    to be within +/- 1% of the true value, what is the minimum number of
+    participants we must ask?
   CorrectAnswer: '8068'
   AnswerTests: omnitest(correctExpr='8068')
-  Hint: See 7.1.3. How does margin of error allow us to determine the sample size given a predetermined level of significance?'
+  Hint: >
+    See 7.1.3. How does margin of error allow us to determine the sample size
+    given a predetermined level of significance?
 
 # Question 6
 - Class:  mult_question
-  Output: 'Retrospective bias corrected confidence intervals differ from the prospective bias corrected confidence intervals because:'
-  AnswerChoices: 'Actually, both correction methods do not differ at all; In the prospective method the magnitude of the bias is estimated without observing the true parameter values; In practice the retrospective bias corrected confidence intervals have a lower coverage rate; In the prospective method more data points are needed in its estimation'
-  CorrectAnswer: 'In the prospective method the magnitude of the bias is estimated without observing the true parameter values'
-  AnswerTests: omnitest(correctVal='In the prospective method the magnitude of the bias is estimated without observing the true parameter values')
+  Output: >
+    Retrospective bias corrected confidence intervals differ from the
+    prospective bias corrected confidence intervals because:
+  AnswerChoices: >
+    Actually, both correction methods do not differ at all;
+    In the prospective method the magnitude of the bias is estimated without
+    observing the true parameter values; In practice the retrospective bias
+    corrected confidence intervals have a lower coverage rate;
+    In the prospective method more data points are needed in its estimation
+  CorrectAnswer: >
+    In the prospective method the magnitude of the bias is estimated without
+    observing the true parameter values
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'In the prospective method the magnitude of the bias is estimated without observing the true parameter values'
+    )
   Hint: See 7.1.3.
 
 # Question 7
 - Class: mult_question
-  Output: 'How many degrees of freedom does a t-statistic require for a sample of size N?'
+  Output: >
+    How many degrees of freedom does a t-statistic require for a sample of
+    size n?
   AnswerChoices: 'n; n-1; n-2; sqrt(n)'
   AnswerTests: omnitest(correctVal='n-1')
   Hint: See 7.1.4.
 
 # Question 8
 - Class: cmd_question
-  Output: 'I flip a fair coin 27 times. What is the variance in the expected number of heads (express to the nearest 0.001)?'
+  Output: >
+    I flip a fair coin 27 times. What is the variance in the expected number of
+    heads (express to the nearest 0.001)?
   CorrectAnswer: '0.009'
   AnswerTests: omnitest(correctExpr='0.009')
   Hint: See 7.1.2. What does the Central Limit Theorem say?
 
 # Question 9
 - Class: cmd_question
-  Output: 'Now, I flip a coin of unknown bias 10 times. It comes up heads 8 times. What is the (non-negative) margin of error, calculated from a 95% confidence interval for the true probability the coin comes up heads (to the nearest 0.01)?'
+  Output: >
+    Now, I flip a coin of unknown bias 10 times.
+    It comes up heads 8 times. What is the (non-negative) margin of error,
+    calculated from a 95% confidence interval for the true probability the
+    coin comes up heads (to the nearest 0.01)?
   CorrectAnswer: '0.25'
   AnswerTests: omnitest(correctExpr='0.25')
   Hint: See 7.1.3.
 
 # Question 10
 - Class: mult_question
-  Output: 'In a sample 50% of the times a coin has landed tails. For 95% confidence and a margin of error of 0.001, roughly how many flips should you we need to check if the coin is actually fair?'
+  Output: >
+    In a sample 50% of the times a coin has landed tails.
+    For 95% confidence and a margin of error of 0.001, roughly how many flips
+    should you we need to check if the coin is actually fair?
   AnswerChoices: '100000; 500000; 1000000; 5000000'
   AnswerTests: omnitest(correctVal='1000000')
   Hint: See 7.1.3. What does this say about sample size?
 
 # Question 11
 - Class: mult_question
-  Output: 'The variance of a Bernoulli distributed random variable is given by: p(1-p). What is the value of p that maximizes the variance of such a variable?'
+  Output: >
+    The variance of a Bernoulli distributed random variable is given by: p(1-p).
+    What is the value of p that maximizes the variance of such a variable?
   AnswerChoices: '0; 1/2; 1/3; 1/4'
   AnswerTests: omnitest(correctVal='1/2')
-  Hint: See 7.1.3. 
+  Hint: See 7.1.3.
+
+- Class: text
+  Output: >
+    You've successfully completed part 1 of the Uncertainty course!

--- a/UNCERTAINTY2/lesson.yaml
+++ b/UNCERTAINTY2/lesson.yaml
@@ -8,15 +8,24 @@
 
 # Question 1
 - Class: mult_question
-  Output: 'Suppose you wish to test whether education has an effect on wages. What could be the null hypothesis?'
-  AnswerChoices: 'Education has no effect on wages; Education has an effect on wages; Wages has no effect on education; Wages has an effect on education'
+  Output: >
+    Suppose you wish to test whether education has an effect on wages.
+    What could be the null hypothesis?
+  AnswerChoices: >
+    Education has no effect on wages; Education has an effect on wages;
+    Wages has no effect on education; Wages has an effect on education'
   CorrectAnswer: 'Education has no effect on wages'
   AnswerTests: omnitest(correctVal='Education has no effect on wages')
   Hint: See 7.2.2.
 
 # Question 2
 - Class: mult_question
-  Output: 'When hiring, large companies get tons of overqualified applicants, so they are fine with rejecting qualified applicants, though they do want to make sure selected applicants are actually qualified.  Given the null hypothesis that applicants are not qualified, do large companies care more about Type I or Type II errors?'
+  Output: >
+    When hiring, large companies get tons of overqualified applicants,
+    so they are fine with rejecting qualified applicants,
+    though they do want to make sure selected applicants are actually qualified.
+    Given the null hypothesis that applicants are not qualified,
+    do large companies care more about Type I or Type II errors?
   AnswerChoices: 'Type I; Type II'
   CorrectAnswer: 'Type I'
   AnswerTests: omnitest(correctVal='Type I')
@@ -24,22 +33,35 @@
 
 # Question 3
 - Class: mult_question
-  Output: 'You wish to conduct a study to test whether students at your university sleep more hours than the national average. What t-test should you use?'
-  AnswerChoices: 'two sample, one-sided; two sample, two-sided; one sample, one-sided; one sample, two-sided'
+  Output: >
+    You wish to conduct a study to test whether students at your university
+    sleep more hours than the national average. What t-test should you use?
+  AnswerChoices: >
+    two sample, one-sided; two sample, two-sided;
+    one sample, one-sided; one sample, two-sided
   CorrectAnswer: 'one sample, one-sided'
   AnswerTests: omnitest(correctVal='one sample, one-sided')
   Hint: See 7.2.5.
 
 # Question 4
 - Class: cmd_question
-  Output: 'You have a coin which you suspect is unfair and instead shows heads with probability 0.7. So, you decide to test this by flipping it exactly once: if heads comes up, you say it is unfair, otherwise, you say it is fair. What is the power of this test (express to the nearest 0.1)?'
+  Output: >
+    You have a coin which you suspect is unfair and instead shows heads with
+    probability 0.7. So, you decide to test this by flipping it exactly once:
+    if heads comes up, you say it is unfair, otherwise, you say it is fair.
+    What is the power of this test (express to the nearest 0.1)?
   CorrectAnswer: '0.7'
   AnswerTests: omnitest(correctExpr='0.7')
   Hint: See 7.2.6.
 
 # Question 5
 - Class: cmd_question
-  Output: 'Flipping a coin once is not super informative, you think to yourself, and so decide to flip the coin two more times. If any heads appear, you say the coin is unfair, otherwise, you say it is fair. With these three flips in total, what is the power of the test now (express to the nearest 0.001)?'
+  Output: >
+    Flipping a coin once is not super informative, you think to yourself,
+    and so decide to flip the coin two more times. If any heads appear,
+    you say the coin is unfair, otherwise, you say it is fair.
+    With these three flips in total, what is the power of the test now
+    (express to the nearest 0.001)?
   CorrectAnswer: '0.973'
   AnswerTests: omnitest(correctExpr='0.973')
   Hint: See 7.2.6.
@@ -47,22 +69,31 @@
 # Question 6
 - Class: mult_question
   Output: 'What does the quantity (1 - power) represent?'
-  AnswerChoices: 'probability of true positive; probability of true negative; probability of false positive; probability of false negative'
+  AnswerChoices: >
+    probability of true positive; probability of true negative;
+    probability of false positive; probability of false negative
   CorrectAnswer: 'probability of false negative'
   AnswerTests: omnitest(correctVal='probability of false negative')
   Hint: See 7.2.6.
 
 # Question 7
 - Class: mult_question
-  Output: 'You repeatedly run statistical tests until you get significance. This fallacy is known as:'
-  AnswerChoices: 'multiple testing; repeated error detection; likelihood fallacy; multiple hypothesis detection'
+  Output: >
+    You repeatedly run statistical tests until you get significance.
+    This fallacy is known as:
+  AnswerChoices: >
+    multiple testing; repeated error detection;
+    likelihood fallacy; multiple hypothesis detection
   CorrectAnswer: 'multiple testing'
   AnswerTests: omnitest(correctVal='multiple testing')
   Hint: See 7.2.4.
 
 # Question 8
 - Class: mult_question
-  Output: 'You think a die is unfair, so you roll twice. If you get 2 sixes in a row, you deem it unfair. What is the probability of a Type I error in this test?'
+  Output: >
+    You think a die is unfair, so you roll twice.
+    If you get 2 sixes in a row, you deem it unfair.
+    What is the probability of a Type I error in this test?
   AnswerChoices: '1/2; 1/6; 1/12; 1/36'
   CorrectAnswer: '1/36'
   AnswerTests: omnitest(correctVal='1/36')
@@ -70,8 +101,12 @@
 
 # Question 9
 - Class: mult_question
-  Output: 'You wish to test whether political sentiment of the average Texan is significantly different from that of the average New Yorker. What test would be appropriate?'
-  AnswerChoices: 'one-sample t-test; two-sample z-test; two-sample t-test; one-sample z-test'
+  Output: >
+    You wish to test whether political sentiment of the average Texan is
+    significantly different from that of the average New Yorker.
+    What test would be appropriate?
+  AnswerChoices: >
+    one-sample t-test; two-sample z-test; two-sample t-test; one-sample z-test
   CorrectAnswer: 'two-sample t-test'
   AnswerTests: omnitest(correctVal='two-sample t-test')
   Hint: See 7.2.5.
@@ -79,7 +114,17 @@
 # Question 10
 - Class: mult_question
   Output: 'How does a t-test primarily differ from a z-test?'
-  AnswerChoices: 'You do not know the population mean; You do not know the population standard deviation; You do not know the confidence level; You do not know if the data is normally distributed'
-  CorrectAnswer: 'You do not know the population standard deviation'
-  AnswerTests: omnitest(correctVal='You do not know the population standard deviation')
+  AnswerChoices: >
+    You do not know the population mean;
+    You do not know the population standard deviation;
+    You do not know the confidence level;
+    You do not know if the data is normally distributed
+  CorrectAnswer: >
+    You do not know the population standard deviation
+  AnswerTests: >-
+    omnitest(correctVal = 'You do not know the population standard deviation')
   Hint: See 7.2.5.
+
+- Class: text
+  Output: >
+    You've successfully completed part 2 of the Uncertainty course!

--- a/UNCERTAINTY3/lesson.yaml
+++ b/UNCERTAINTY3/lesson.yaml
@@ -9,15 +9,35 @@
 # Question 1
 - Class: mult_question
   Output: 'What is the exogeneity assumption behind linear regression?'
-  AnswerChoices: 'The mean of the errors does not depend on the explanatory variables and is equal to 0; The variance of the errors does not depend on the explanatory variables and is equal to 0; The median of the errors does not depend on the explanatory variables and is equal to 0'
-  CorrectAnswer: 'The mean of the errors does not depend on the explanatory variables and is equal to 0'
-  AnswerTests: omnitest(correctVal='The mean of the errors does not depend on the explanatory variables and is equal to 0')
+  AnswerChoices: >
+    The mean of the errors does not depend on the explanatory variables
+    and is equal to 0;
+    The variance of the errors does not depend on the explanatory variables
+    and is equal to 0;
+    The median of the errors does not depend on the explanatory variables
+    and is equal to 0
+  CorrectAnswer: >
+    The mean of the errors does not depend on the explanatory variables
+    and is equal to 0
+  AnswerTests: >
+    omnitest(
+      correctVal =
+        'The mean of the errors does not depend on the explanatory variables and is equal to 0'
+    )
   Hint: See 7.3.1.
 
 # Question 2
 - Class: mult_question
-  Output: 'You observe that students who come to class tend to score higher on exams, so you conclude that attendance positively impacts exam performance. Yet, you fail to account for the effect of internal motivation. What term best describes this problem?'
-  AnswerChoices: 'omitted variable bias; omitted independent variable bias; exogeneity; Type I error'
+  Output: >
+    You observe that students who come to class tend to score higher on exams,
+    so you conclude that attendance positively impacts exam performance.
+    Yet, you fail to account for the effect of internal motivation.
+    What term best describes this problem?
+  AnswerChoices: >
+    omitted variable bias;
+    omitted independent variable bias;
+    exogeneity;
+    Type I error
   CorrectAnswer: 'omitted variable bias'
   AnswerTests: omnitest(correctVal='omitted variable bias')
   Hint: See 7.3.1.
@@ -25,22 +45,39 @@
 # Question 3
 - Class: mult_question
   Output: 'What is homoskedasticity?'
-  AnswerChoices: 'independent errors and variance that does not depend on the explanatory variables; independent errors and expectation that does not depend on the explanatory variables; expectation of errors equals their variance; variance of errors depends on their expectation'
-  CorrectAnswer: 'independent errors and variance that does not depend on the explanatory variables'
-  AnswerTests: omnitest(correctVal='independent errors and variance that does not depend on the explanatory variables')
-  Hint: See 7.3.2. 
+  AnswerChoices: >
+    independent errors and variance that does not depend on the
+    explanatory variables;
+    independent errors and expectation that does not depend on the
+    explanatory variables;
+    expectation of errors equals their variance;
+    variance of errors depends on their expectation
+  CorrectAnswer: >
+    independent errors and variance that does not depend on the
+    explanatory variables
+  AnswerTests: >-
+    omnitest(
+      correctVal =
+        'independent errors and variance that does not depend on the explanatory variables'
+    )
+  Hint: See 7.3.2.
 
 # Question 4
 - Class: mult_question
-  Output: 'In R, what term should you include in a linear regression formula to leave out the intercept?'
+  Output: >
+    In R, what term should you include in a linear regression formula
+    to leave out the intercept?
   AnswerChoices: '1; -1; 0; -2'
   CorrectAnswer: '-1'
   AnswerTests: omnitest(correctVal='-1')
-  Hint: See 7.3.1. 
+  Hint: See 7.3.1.
 
 # Question 5
 - Class: mult_question
-  Output: 'If the correlation between X and Y is 4, the standard deviation of X is 1 and the standard deviation of Y is 2, then what is the covariance between X and Y?'
+  Output: >
+    If the correlation between X and Y is 4,
+    the standard deviation of X is 1 and the standard deviation of Y is 2,
+    then what is the covariance between X and Y?
   AnswerChoices: '8; 4; 2; 1'
   CorrectAnswer: '8'
   AnswerTests: omnitest(correctVal='8')
@@ -48,14 +85,22 @@
 
 # Question 6
 - Class: cmd_question
-  Output: 'For 765 observations and 8 explanatory variables in a linear regression model with an intercept, when calculating the p-values for the coefficients how many degrees of freedom will the t-statistic have?'
+  Output: >
+    For 765 observations and 8 explanatory variables
+    in a linear regression model with an intercept,
+    when calculating the p-values for the coefficients
+    how many degrees of freedom will the t-statistic have?
   CorrectAnswer: '756'
   AnswerTests: omnitest(correctExpr='756')
   Hint: See toward the end of 7.3.2.
 
 # Question 7
 - Class: mult_question
-  Output: 'The variance of a variable can be written as V(x) = E[x^2] - E[x]^2. Using that formula and the properties of the residuals: What is a valid expression for the Variance of the residuals in a linear regression (where e denotes the vector of resisuals)?'
+  Output: >
+    The variance of a variable can be written as V(x) = E[x^2] - E[x]^2.
+    Using that formula and the properties of the residuals:
+    What is a valid expression for the Variance of the residuals in a
+    linear regression (where e denotes the vector of resisuals)?
   AnswerChoices: 'E[e^2] - E[e]^2; E[e^2]; both expressions are correct'
   CorrectAnswer: 'both expressions are correct'
   AnswerTests: omnitest(correctVal='both expressions are correct')
@@ -63,15 +108,23 @@
 
 # Question 8
 - Class: mult_question
-  Output: 'When might you use adjusted R^2 over R^2, holding everything else equal?'
-  AnswerChoices: 'When there are many observations; When there are many predictors; When there are many degrees of freedom; When the data is nonlinear'
+  Output: >
+    When might you use adjusted R^2 over R^2, holding everything else equal?
+  AnswerChoices: >
+    When there are many observations;
+    When there are many predictors;
+    When there are many degrees of freedom;
+    When the data is nonlinear
   CorrectAnswer: 'When there are many predictors'
   AnswerTests: omnitest(correctVal='When there are many predictors')
   Hint: See toward the end of 7.3.2.
 
 # Question 9
 - Class: mult_question
-  Output: 'True or False: In a linear regression model, if two confidence intervals of two variables overlap, this implies that the confidence interval for the difference between those variables must contain 0.'
+  Output: >
+    True or False: In a linear regression model, if two confidence intervals
+    of two variables overlap, this implies that the confidence interval for the
+    difference between those variables must contain 0.
   AnswerChoices: 'True; False'
   CorrectAnswer: 'False'
   AnswerTests: omnitest(correctVal='False')
@@ -79,8 +132,15 @@
 
 # Question 10
 - Class: mult_question
-  Output: 'What is the relevant parameter if you wanted to set the significance level for confidence intervals within the predict() function (type a single word within double quotes)?'
+  Output: >
+    What is the relevant parameter if you wanted to set the significance level
+    for confidence intervals within the predict() function (type a single word
+    within double quotes)?
   AnswerChoices: 'p-value; level; significance'
   CorrectAnswer: 'level'
   AnswerTests: omnitest(correctVal='level')
   Hint: See 7.3.3.
+
+- Class: text
+  Output: >
+    You've successfully completed part 3 of the Uncertainty course!


### PR DESCRIPTION
Hi Kosuke and `qss-swirl` maintainers,

I went through the entire qss-swirl and added some legitimate answers that were not accepted as answers before. For example, in MEASUREMENT2, 

```
x <- matrix(seq(10), nrow = 2, byrow = TRUE)
```

is also a legitimate answer, because 
1. you need only one of `ncol` or `nrow` 
2. `seq(10)` is an acceptable substitute of `1:10`. 

About this pull request:

* The files *look* like they are complete reworks, simply because I cut the yaml code width to 80 characters whenever possible for readability. So most of the file changes are actually just cosmetic.
* I have also fixed typos in several places.
* I have also added the ending "You have successfully..." messages when they were missing. 

I have gone through several runs of `demo_lesson` for each updated file, but let me know if there are any remaining errors. 

I would like to also suggest changing Question 5 on CAUSALITY1 so that the labels are actually different names from the column names, because `table(resume$sex, resume$call)` will also give you the same console output. You only get to figure out that you have not really labeled it after storing it and calling `labels`. I think this could be confusing for students.

I start teaching with QSS in a week, and I look forward to it. 

Best,
Silvia