### PR TITLE
INTRO02: last four obs question: c(4, 5, 6, 7) also valid

### DIFF
--- a/INTRO2/lesson.yaml
+++ b/INTRO2/lesson.yaml
@@ -163,6 +163,9 @@
   AnswerTests: >-
     any_of_exprs(
       'UNpop[4:7, "year"]', 'UNpop[4:7, 2]', 'UNpop$year[4:7]',
+      'UNpop$year[c(4, 5, 6, 7)]',
+      'UNpop[c(4, 5, 6, 7), "year"]',
+      'UNpop[c(4, 5, 6, 7), 2]',
       'UNpop[c(4:7), "year"]', 'UNpop[c(4:7), 2]', 'UNpop$year[c(4:7)]',
       'UNpop$year[seq(from = 4, to = 7)]',
       'UNpop$year[seq(from = 4, to = 7, by = 1)]',


### PR DESCRIPTION
Hi Kosuke,

Because question 15 in INTRO2 does not ask for an explicit use of colon or seq (although is implied from the book), I think explicit concatenation should also be accepted, e.g., `UNpop$year[c(4, 5, 6, 7)]`. Thank you very much!

Best,
Silvia